### PR TITLE
 Added the predis/predis package for redis-php setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",
+	"predis/predis": "^2.1",
         "laravel/tinker": "^2.8"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",
-	"predis/predis": "^2.1",
+	    "predis/predis": "^2.1",
         "laravel/tinker": "^2.8"
     },
     "require-dev": {


### PR DESCRIPTION
This update enables our PHP application to connect to a Redis instance for creating a messaging queue.

The change involves adding the "predis/predis" package, allowing PHP to connect to Redis.