### PR TITLE
Created a response helper function

### DIFF
--- a/app/Helpers/ResponseHelper.php
+++ b/app/Helpers/ResponseHelper.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Helpers;
+
+class ResponseHelper
+{
+    public static function validationError($errors)
+    {
+        $formattedErrors = [];
+        foreach ($errors->toArray() as $field => $messageArray) {
+            foreach ($messageArray as $message) {
+                $formattedErrors[] = [
+                    'field' => $field,
+                    'message' => $message,
+                ];
+            }
+        }
+        return response()->json([
+            'errors' => $formattedErrors,
+        ], 422);
+    }
+
+    public static function response($status, $message, $data = null, $statusCode = 200 ){
+        $response = [
+            'status' => $status,
+            'message' => $message,
+        ];
+        if (!is_null($data)) {
+            $response['data'] = $data;
+        }
+        if (!($statusCode == 200 || $statusCode == 201)) {
+            $response['statusCode'] = $statusCode;
+        }
+        return response()->json($response, $statusCode);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A response helper function to ensure consistent responses.
​
## Description
<!--- Describe your changes in detail -->
Formatting responses to the expected response structure, for:
1. Successful response, 
2. Unsuccessful response, and
3. Validation-error responses.

### Case of validation error
- **Usage:** `return ResponseHelper::validationError($validator->errors());`
- **Output:** `422`

```
{
  "errors": [
    {
      "field": "String",
      "message": "String"
    }
  ]
}
```

### Case of successful response
- **Usage:** `return ResponseHelper::response('success', <message>, <data>, HTTP_RESPONSE);`
- **Output:** `HTTP_RESPONSE`
```
{
  "status": "success",
  "message": <message>,
  "data": <data>,
 "status_code": HTTP_RESPONSE
}
```

### Case of unsuccessful response
- **Usage:** `return ResponseHelper::response(<Error code>, <Error message>, null, HTTP_RESPONSE);`
- **Output:** `HTTP_RESPONSE`
```
{
  "status": <Error code>,
  "message": <Error message>,
 "status_code": HTTP_RESPONSE
}
```
​
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- To keep the responses consistent and avoid issues between frontend and backend.
- To ensure all responses follow the required format
​​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.