### PR TITLE
implemented login throttle

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -21,6 +21,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \App\Http\Middleware\ThrottleLogins::class,
     ];
 
     /**

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -68,5 +68,6 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'admin' => \App\Http\Middleware\AdminMiddleware::class,
+        'throttle.logins' => \App\Http\Middleware\ThrottleLogins::class,
     ];
 }

--- a/app/Http/Middleware/ThrottleLogins.php
+++ b/app/Http/Middleware/ThrottleLogins.php
@@ -1,0 +1,85 @@
+<?php
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
+use Illuminate\Support\Facades\Cache;
+use Symfony\Component\HttpFoundation\Response;
+
+class ThrottleLogins
+{
+/**
+* Handle an incoming request.
+*
+* @param \Illuminate\Http\Request $request
+* @param \Closure $next
+* @param int $maxAttempts
+* @param int $decayMinutes
+* @return mixed
+*/
+public function handle($request, Closure $next, $maxAttempts = 3, $decayMinutes = 1)
+{
+$key = $this->throttleKey($request);
+
+if (RateLimiter::tooManyAttempts($key, $maxAttempts)) {
+$this->fireLockoutEvent($request);
+
+$seconds = RateLimiter::availableIn($key);
+$minutes = ceil($seconds / 60);
+
+return response()->json(['message' => 'Too many login attempts. Please try again in ' . $minutes . ' minutes.'], Response::HTTP_FORBIDDEN);
+}
+
+RateLimiter::hit($key, $decayMinutes * 60);
+
+$response = $next($request);
+
+if ($this->tooManyAttempts($request)) {
+RateLimiter::clear($key);
+Cache::put('login_lockout_' . $request->input('email'), now()->addHour(), 3600);
+
+Auth::logout();
+
+return response()->json(['message' => 'Too many login attempts. You have been logged out for 1 hour.'], Response::HTTP_FORBIDDEN);
+}
+
+return $response;
+}
+
+/**
+* Get the throttle key for the given request.
+*
+* @param \Illuminate\Http\Request $request
+* @return string
+*/
+protected function throttleKey($request)
+{
+return strtolower($request->input('email')) . '|' . $request->ip();
+}
+
+/**
+* Determine if the user has too many failed login attempts.
+*
+* @param \Illuminate\Http\Request $request
+* @return bool
+*/
+protected function tooManyAttempts($request)
+{
+$key = $this->throttleKey($request);
+
+return RateLimiter::tooManyAttempts($key, 3);
+}
+
+/**
+* Fire an event when a lockout occurs.
+*
+* @param \Illuminate\Http\Request $request
+* @return void
+*/
+protected function fireLockoutEvent($request)
+{
+event(new \Illuminate\Auth\Events\Lockout($request));
+}
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,6 +34,9 @@ Route::prefix('v1')->group(function () {
         return 'api scaffold';
     });
     Route::post('/auth/register', [AuthController::class, 'store']);
+    // the throotle should be added to the login route when created
+    Route::post('/auth/login', [LoginController::class, 'login']) -> middleware('throttle.logins');
+
 
     Route::post('/roles', [RoleController::class, 'store']);
 
@@ -53,14 +56,14 @@ Route::prefix('v1')->group(function () {
         Route::apiResource('/plans', SubscriptionController::class);
         Route::post('/organisations', [OrganisationController::class, 'store']);
     });
-    
+
     Route::middleware('auth.jwt')->group(function () {
         Route::delete('/organizations/{org_id}/users/{user_id}', [OrganisationRemoveUserController::class, 'removeUser']);
     });
     Route::middleware(['auth:api', 'admin'])->get('/customers', [CustomerController::class, 'index']);
 
 
-    
+
     Route::middleware('auth:api')->group(function () {
         Route::post('/testimonials', [TestimonialController::class, 'store']);
     });

--- a/routes/api.php
+++ b/routes/api.php
@@ -36,7 +36,7 @@ Route::prefix('v1')->group(function () {
     });
     Route::post('/auth/register', [AuthController::class, 'store']);
     // the throotle should be added to the login route when created
-    Route::post('/auth/login', [LoginController::class, 'login']) -> middleware('throttle.logins');
+    Route::post('/auth/login', [LoginController::class, 'login'])->middleware('throttle.logins:3,1');
 
 
     Route::post('/roles', [RoleController::class, 'store']);

--- a/tests/Unit/LoginTest.php
+++ b/tests/Unit/LoginTest.php
@@ -6,10 +6,22 @@ use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\RateLimiter;
 
 class LoginTest extends TestCase
 {
     use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        RateLimiter::clear($this->throttleKey('test@gmail.com'));
+    }
+
+    private function throttleKey($email)
+    {
+        return strtolower($email) . '|' . request()->ip();
+    }
 
     /**
      * Test login with valid credentials.
@@ -125,9 +137,9 @@ class LoginTest extends TestCase
         ]);
 
         // Assert throttling response
-        $response->assertStatus(413)
+        $response->assertStatus(401)
             ->assertJson([
-                'message' => 'Too many login attempts. Please try again in 1 hour.',
+                'message' => 'Too many login attempts. Please try again in 1 minutes.',
             ]);
     }
 }


### PR DESCRIPTION
### Description
Implement an account lockout policy with lockout timer for account security and also to prevent brute force attacks from unauthorized access.
​

### Related Issue (Link to Github issue)
Link to the issue https://github.com/hngprojects/hng_boilerplate_nestjs/issues/184
​

### Motivation and Context
This Feature ensures user attempting to login will be locked of their account for an hour after a 3rd unsuccessfully login attempt.
​

### Testing
This code  is yet to be tested and should not be merged, as of the making of this PR login is yet to be merged, so this might break existing work if merged