### PR TITLE
[feat] Fetch Single Testimonial 

### DIFF
--- a/CONTRIBUTORS_GUIDE.md
+++ b/CONTRIBUTORS_GUIDE.md
@@ -4,6 +4,8 @@ Thank you for considering contributing to [App Name]! We welcome all types of co
 
 ## Contribution Rules
 
+name Nwanozie Promise 
+
 1. **Follow the Code of Conduct:** Please read and adhere to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 2. **Style Guide:** Ensure your code follows the project's coding style. This includes proper indentation, variable naming conventions, and inline comments where necessary.

--- a/app/Http/Controllers/Api/V1/Testimonial/TestimonialController.php
+++ b/app/Http/Controllers/Api/V1/Testimonial/TestimonialController.php
@@ -68,10 +68,37 @@ class TestimonialController extends Controller
     /**
      * Display the specified resource.
      */
-    public function show(Testimonial $testimonial)
+
+
+    public function show(Testimonial $testimonial_id)
     {
-        //
+        $user = Auth::user();
+
+        if (!$user) {
+            return response()->json([
+                'status' => 'Unauthorized',
+                'message' => 'Unauthorized. Please log in.',
+                'status_code' => 401,
+            ], 401);
+        }
+
+        $testimonial = Testimonial::find($testimonial_id);
+
+        if (!$testimonial) {
+            return response()->json([
+                'status' => 'Not Found',
+                'message' => 'Testimonial not found.',
+                'status_code' => 404,
+            ], 404);
+        }
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Testimonial fetched successfully',
+            'data' => $testimonial,
+        ], 200);
     }
+
 
     /**
      * Show the form for editing the specified resource.

--- a/app/Http/Controllers/Api/V1/Testimonial/TestimonialController.php
+++ b/app/Http/Controllers/Api/V1/Testimonial/TestimonialController.php
@@ -38,8 +38,8 @@ class TestimonialController extends Controller
 
         if (!$user) {
             return response()->json([
-                'status' => 'Unauthorized',
-                'message' => 'Unauthorized. Please log in.',
+                'status' => 'Unauthenticated',
+                'message' => 'Unauthenticated. Please log in.',
                 'status_code' => 401,
             ], 401);
         }

--- a/app/Http/Controllers/Api/V1/Testimonial/TestimonialController.php
+++ b/app/Http/Controllers/Api/V1/Testimonial/TestimonialController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\UpdateTestimonialRequest;
 use App\Models\Testimonial;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class TestimonialController extends Controller
 {
@@ -70,7 +71,56 @@ class TestimonialController extends Controller
      */
 
 
-    public function show(Testimonial $testimonial_id)
+    // public function show(Testimonial $testimonial_id)
+    // {
+    //     $user = Auth::user();
+
+    //     if (!$user) {
+    //         return response()->json([
+    //             'status' => 'Unauthorized',
+    //             'message' => 'Unauthorized. Please log in.',
+    //             'status_code' => 401,
+    //         ], 401);
+    //     }
+
+    //     $testimonial = Testimonial::find($testimonial_id);
+
+    //     if (!$testimonial) {
+    //         return response()->json([
+    //             'status' => 'Not Found',
+    //             'message' => 'Testimonial not found.',
+    //             'status_code' => 404,
+    //         ], 404);
+    //     }
+
+    //     return response()->json([
+    //         'status' => 'success',
+    //         'message' => 'Testimonial fetched successfully',
+    //         'data' => $testimonial,
+    //     ], 200);
+    // }
+
+//     public function show(Testimonial $testimonial)
+// {
+//     $user = Auth::user();
+
+//     if (!$user) {
+//         return response()->json([
+//             'status' => 'Unauthorized',
+//             'message' => 'Unauthorized. Please log in.',
+//             'status_code' => 401,
+//         ], 401);
+//     }
+
+//     return response()->json([
+//         'status' => 'success',
+//         'message' => 'Testimonial fetched successfully',
+//         'data' => $testimonial,
+//     ], 200);
+// }
+
+
+    public function show($id)
     {
         $user = Auth::user();
 
@@ -82,9 +132,9 @@ class TestimonialController extends Controller
             ], 401);
         }
 
-        $testimonial = Testimonial::find($testimonial_id);
-
-        if (!$testimonial) {
+        try {
+            $testimonial = Testimonial::findOrFail($id);
+        } catch (ModelNotFoundException $e) {
             return response()->json([
                 'status' => 'Not Found',
                 'message' => 'Testimonial not found.',

--- a/app/Http/Controllers/Api/V1/Testimonial/TestimonialController.php
+++ b/app/Http/Controllers/Api/V1/Testimonial/TestimonialController.php
@@ -38,8 +38,8 @@ class TestimonialController extends Controller
 
         if (!$user) {
             return response()->json([
-                'status' => 'Unauthenticated',
-                'message' => 'Unauthenticated. Please log in.',
+                'status' => 'Unauthorized',
+                'message' => 'Unauthorized. Please log in.',
                 'status_code' => 401,
             ], 401);
         }
@@ -120,34 +120,34 @@ class TestimonialController extends Controller
 // }
 
 
-    public function show($id)
-    {
-        $user = Auth::user();
+public function show($id)
+{
+    $user = Auth::user();
 
-        if (!$user) {
-            return response()->json([
-                'status' => 'Unauthorized',
-                'message' => 'Unauthorized. Please log in.',
-                'status_code' => 401,
-            ], 401);
-        }
-
-        try {
-            $testimonial = Testimonial::findOrFail($id);
-        } catch (ModelNotFoundException $e) {
-            return response()->json([
-                'status' => 'Not Found',
-                'message' => 'Testimonial not found.',
-                'status_code' => 404,
-            ], 404);
-        }
-
+    if (!$user) {
         return response()->json([
-            'status' => 'success',
-            'message' => 'Testimonial fetched successfully',
-            'data' => $testimonial,
-        ], 200);
+            'status' => 'Unauthorized',
+            'message' => 'Unauthorized. Please log in.',
+            'status_code' => 401,
+        ], 401);
     }
+
+    try {
+        $testimonial = Testimonial::findOrFail($id);
+    } catch (ModelNotFoundException $e) {
+        return response()->json([
+            'status' => 'Not Found',
+            'message' => 'Testimonial not found.',
+            'status_code' => 404,
+        ], 404);
+    }
+
+    return response()->json([
+        'status' => 'success',
+        'message' => 'Testimonial fetched successfully',
+        'data' => $testimonial,
+    ], 200);
+}
 
 
     /**

--- a/database/factories/TestimonialFactory.php
+++ b/database/factories/TestimonialFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Testimonial;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TestimonialFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Testimonial::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'user_id' => User::factory(),
+            'name' => $this->faker->name,
+            'content' => $this->faker->paragraph,
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -55,16 +55,17 @@ Route::prefix('v1')->group(function () {
         Route::apiResource('/plans', SubscriptionController::class);
         Route::post('/organisations', [OrganisationController::class, 'store']);
     });
-    
+
     Route::middleware('auth.jwt')->group(function () {
         Route::delete('/organizations/{org_id}/users/{user_id}', [OrganisationRemoveUserController::class, 'removeUser']);
     });
     Route::middleware(['auth:api', 'admin'])->get('/customers', [CustomerController::class, 'index']);
 
 
-    
+
     Route::middleware('auth:api')->group(function () {
         Route::post('/testimonials', [TestimonialController::class, 'store']);
+        Route::get('/{testimonial_id}', [TestimonialController::class, 'show']);
     });
 
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -65,7 +65,7 @@ Route::prefix('v1')->group(function () {
 
     Route::middleware('auth:api')->group(function () {
         Route::post('/testimonials', [TestimonialController::class, 'store']);
-        Route::get('/{testimonial_id}', [TestimonialController::class, 'show']);
+        Route::get('/testimonials/{testimonial_id}', [TestimonialController::class, 'show']);
     });
 
 });

--- a/tests/Feature/TestimonialTest.php
+++ b/tests/Feature/TestimonialTest.php
@@ -78,6 +78,7 @@ class TestimonialTest extends TestCase
         $response->assertJson([
             'status' => 'Unauthorized',
             'message' => 'Unauthorized. Please log in.',
+            'status_code' => 401,
         ]);
     }
 
@@ -119,6 +120,8 @@ class TestimonialTest extends TestCase
         $response->assertJson([
             'status' => 'Not Found',
             'message' => 'Testimonial not found.',
+            'status_code' => 404,
         ]);
     }
+
 }

--- a/tests/Feature/TestimonialTest.php
+++ b/tests/Feature/TestimonialTest.php
@@ -76,8 +76,8 @@ class TestimonialTest extends TestCase
 
         $response->assertStatus(401);
         $response->assertJson([
-            'status' => 'Unauthorized',
-            'message' => 'Unauthorized. Please log in.',
+            'status' => 'Unauthenticated',
+            'message' => 'Unauthenticated. Please log in.',
             'status_code' => 401,
         ]);
     }

--- a/tests/Feature/TestimonialTest.php
+++ b/tests/Feature/TestimonialTest.php
@@ -76,9 +76,10 @@ class TestimonialTest extends TestCase
 
         $response->assertStatus(401);
         $response->assertJson([
-            'status' => 'Unauthenticated',
-            'message' => 'Unauthenticated. Please log in.',
-            'status_code' => 401,
+            // 'status' => 'Unauthenticated',
+            // 'message' => 'Unauthenticated. Please log in.',
+            // 'status_code' => 401,
+            'message' => 'Unauthenticated.',
         ]);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​
## Description
Implemented the show method in TestimonialController to fetch a testimonial by its ID. This method ensures that the user is authenticated and returns appropriate status codes based on whether the testimonial exists and whether the user is authenticated.
​
## Related Issue (Link to Github issue)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
[Link](https://github.com/hngprojects/hng_boilerplate_php_laravel_web/issues/43)
​
## Motivation and Context
This change is required to allow authenticated users to fetch specific testimonials by their IDs. 
​
## How Has This Been Tested?
Tested using Postman to ensure the following:

    Unauthenticated users receive a 401 status code.
    Authenticated users can fetch testimonials by ID and receive a 200 status code.
    Requests for non-existent testimonials return a 404 status code.

Wrote unit tests to cover the show method for different scenarios (authenticated user, non-authenticated user, testimonial exists, testimonial does not exist).
​
## Screenshots (if appropriate - Postman, etc):
​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
