### PR TITLE
feat: Implement Logout

### DIFF
--- a/app/Http/Controllers/Api/V1/Auth/LoginController.php
+++ b/app/Http/Controllers/Api/V1/Auth/LoginController.php
@@ -83,4 +83,32 @@ class LoginController extends Controller
             ]
         ], 200);
     }
+
+    public function logout()
+    {
+        try {
+            JWTAuth::parseToken()->invalidate(true);
+            return response()->json([
+                'message' => 'Logout successful',
+                'status_code' => 200
+            ], 200);
+        } catch (\Tymon\JWTAuth\Exceptions\JWTException $e) {
+            return response()->json([
+                'message' => $e->getMessage(),
+                'error' => $this->getErrorCode($e),
+                'status_code' => 401
+            ], 401);
+        }
+    }
+
+    private function getErrorCode($exception)
+    {
+        if ($exception instanceof \Tymon\JWTAuth\Exceptions\TokenExpiredException) {
+            return 'token_expired';
+        } elseif ($exception instanceof \Tymon\JWTAuth\Exceptions\TokenInvalidException) {
+            return 'token_invalid';
+        } else {
+            return 'token_absent';
+        }
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,6 +37,7 @@ Route::prefix('v1')->group(function () {
     });
     Route::post('/auth/register', [AuthController::class, 'store']);
     Route::post('/auth/login', [LoginController::class, 'login']);
+    Route::post('/auth/logout', [LoginController::class, 'logout'])->middleware('auth:api');
     Route::post('/roles', [RoleController::class, 'store']);
 
     Route::apiResource('/users', UserController::class);
@@ -56,18 +57,15 @@ Route::prefix('v1')->group(function () {
         Route::apiResource('/plans', SubscriptionController::class);
         Route::post('/organisations', [OrganisationController::class, 'store']);
     });
-    
+
     Route::middleware('auth.jwt')->group(function () {
         Route::delete('/organizations/{org_id}/users/{user_id}', [OrganisationRemoveUserController::class, 'removeUser']);
     });
     Route::middleware(['auth:api', 'admin'])->get('/customers', [CustomerController::class, 'index']);
 
 
-    
+
     Route::middleware('auth:api')->group(function () {
         Route::post('/testimonials', [TestimonialController::class, 'store']);
     });
-
 });
-
-

--- a/tests/Unit/LogoutTest.php
+++ b/tests/Unit/LogoutTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Unit\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Api\V1\Auth\LoginController;
+use Illuminate\Http\JsonResponse;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+use Tymon\JWTAuth\Exceptions\TokenExpiredException;
+use Tymon\JWTAuth\Exceptions\TokenInvalidException;
+use Tymon\JWTAuth\Exceptions\JWTException;
+
+class LogoutTest extends TestCase
+{
+    protected $loginController;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->loginController = new LoginController();
+    }
+
+    public function testSuccessfulLogout()
+    {
+        JWTAuth::shouldReceive('parseToken->invalidate')
+            ->once()
+            ->with(true)
+            ->andReturn(true);
+
+        $response = $this->loginController->logout();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Logout successful', json_decode($response->getContent())->message);
+    }
+
+    public function testLogoutWithExpiredToken()
+    {
+        JWTAuth::shouldReceive('parseToken->invalidate')
+            ->once()
+            ->with(true)
+            ->andThrow(new TokenExpiredException('Token has expired'));
+
+        $response = $this->loginController->logout();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertEquals('Token has expired', json_decode($response->getContent())->message);
+        $this->assertEquals('token_expired', json_decode($response->getContent())->error);
+    }
+
+    public function testLogoutWithInvalidToken()
+    {
+        JWTAuth::shouldReceive('parseToken->invalidate')
+            ->once()
+            ->with(true)
+            ->andThrow(new TokenInvalidException('Token is invalid'));
+
+        $response = $this->loginController->logout();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertEquals('Token is invalid', json_decode($response->getContent())->message);
+        $this->assertEquals('token_invalid', json_decode($response->getContent())->error);
+    }
+
+    public function testLogoutWithMissingToken()
+    {
+        JWTAuth::shouldReceive('parseToken->invalidate')
+            ->once()
+            ->with(true)
+            ->andThrow(new JWTException('Token is missing'));
+
+        $response = $this->loginController->logout();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertEquals('Token is missing', json_decode($response->getContent())->message);
+        $this->assertEquals('token_absent', json_decode($response->getContent())->error);
+    }
+}


### PR DESCRIPTION
### ​Description
This  endpoint  handles user logout. it invalidates the user's authentication token, effectively logging them out of the system. It also handles invalid or missing tokens gracefully by returning appropriate error messages. Additionally, ensure that the token invalidation process is secure and that tests are implemented to verify functionality.
​
## Related Issue (Link to Github issue)
[link to issue](https://github.com/hngprojects/hng_boilerplate_nestjs/issues/230)
​
## Motivation and Context
This endpoint ensures that users are able to logout the app
​
## How Has This Been Tested?

- if a user is not authenticated and attempt logout it returns a status code of 401(unauthenticated)
- if a user logs out successfully, it clears the token and returns a status code of 200

​
## Screenshots (if appropriate - Postman, etc):
<img width="742" alt="logout1" src="https://github.com/user-attachments/assets/f25dacf8-b9f1-404d-abf5-e1cbc49bc475">

​
<img width="757" alt="logout2" src="https://github.com/user-attachments/assets/df4cb0dd-a44b-4aa4-b6fa-b5ff47cd9666">

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
