### PR TITLE
Product Delete Endpoint

### DIFF
--- a/app/Http/Controllers/Api/V1/ProductController.php
+++ b/app/Http/Controllers/Api/V1/ProductController.php
@@ -38,7 +38,6 @@ class ProductController extends Controller
                 'description' => $product->description,
             ]
         ], 201);
-
     }
 
     /**
@@ -62,6 +61,21 @@ class ProductController extends Controller
      */
     public function destroy(string $id)
     {
-        //
+        $user = auth()->user();
+        $product = $user->products()->find($id);
+
+        if (!$product) {
+            return response()->json([
+                'message' => 'Product not found',
+                'status_code' => 404,
+            ], 404);
+        }
+
+        $product->delete();
+
+        return response()->json([
+            'message' => 'Product deleted successfully',
+            'status_code' => 200,
+        ], 200);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,13 +15,12 @@ use App\Http\Controllers\Api\V1\Admin\CustomerController;
 use App\Http\Controllers\Api\V1\Admin\Plan\FeatureController;
 use App\Http\Controllers\Api\V1\Admin\Plan\SubscriptionController;
 use App\Http\Controllers\Api\V1\Testimonial\TestimonialController;
-
 use App\Http\Controllers\Api\V1\Organisation\OrganisationController;
 use App\Http\Controllers\Api\V1\Organisation\OrganisationRemoveUserController;
 use App\Http\Controllers\Api\V1\Auth\LoginController;
 use App\Http\Middleware\LoginAttempts;
-
 use App\Http\Controllers\Api\V1\JobController;
+
 /*
 |--------------------------------------------------------------------------
 | API Routes
@@ -48,11 +47,11 @@ Route::prefix('v1')->group(function () {
 
     Route::middleware('throttle:10,1')->get('/topics/search', [ArticleController::class, 'search']);
 
-
-    Route::middleware('auth:api')->group(function() {
+    Route::middleware('auth:api')->group(function () {
         Route::post('/products', [ProductController::class, 'store']);
+        Route::delete('/products/{id}', [ProductController::class, 'destroy']);
     });
-      
+    
     Route::middleware('throttle:10,1')->get('/help-center/topics/search', [ArticleController::class, 'search']);
     Route::post('/contact', [ContactController::class, 'sendInquiry']);
 
@@ -69,9 +68,8 @@ Route::prefix('v1')->group(function () {
         Route::get('/organisations', [OrganisationController::class, 'index']);
         Route::delete('/organisations/{org_id}/users/{user_id}', [OrganisationRemoveUserController::class, 'removeUser']);
     });
+
     Route::middleware(['auth:api', 'admin'])->get('/customers', [CustomerController::class, 'index']);
-
-
 
     Route::middleware('auth:api')->group(function () {
         Route::post('/testimonials', [TestimonialController::class, 'store']);

--- a/tests/Unit/ProductCreationTest.php
+++ b/tests/Unit/ProductCreationTest.php
@@ -3,6 +3,8 @@ namespace Tests\Unit;
 
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+
 
 class ProductCreationTest extends TestCase
 {
@@ -34,6 +36,10 @@ class ProductCreationTest extends TestCase
         // Create a product as the authenticated user
         $product = [
             'name' => 'Test Product',
+            'price' => 400,
+            'slug' => Str::slug("test product"),
+            'tags' => "thanks, done",
+            "imageUrl" => "xyx.com/img",
             'description' => 'Test description'
         ];
 
@@ -47,6 +53,8 @@ class ProductCreationTest extends TestCase
         // // Assert that the product was created in the database
         $this->assertDatabaseHas('products', [
             'name' => 'Test Product',
+            'price' => 400,
+            'slug' => Str::slug("test product"),
             'description' => 'Test description'
         ]);
     }

--- a/tests/Unit/ProductDeleteTest.php
+++ b/tests/Unit/ProductDeleteTest.php
@@ -1,8 +1,10 @@
 <?php
+
 namespace Tests\Unit;
 
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
 
 
 class ProductDeleteTest extends TestCase

--- a/tests/Unit/ProductDeleteTest.php
+++ b/tests/Unit/ProductDeleteTest.php
@@ -2,8 +2,7 @@ namespace Tests\Unit;
 
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use App\Models\User; 
-use App\Models\Product;
+
 
 class ProductDeleteTest extends TestCase
 {

--- a/tests/Unit/ProductDeleteTest.php
+++ b/tests/Unit/ProductDeleteTest.php
@@ -1,112 +1,16 @@
-<?php
 namespace Tests\Unit;
 
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User; 
+use App\Models\Product;
 
 class ProductDeleteTest extends TestCase
 {
     use RefreshDatabase;
-    public function test_authenticated_user_can_create_product()
-{
-    $user = [
-        'name' => 'Test User',
-        'email' => 'testuser@example.com',
-        'password' => 'password',
-        'password_confirmation' => 'password',
-    ];
 
-    $response = $this->postJson('/api/v1/auth/register', $user);
-
-    $response->assertStatus(201);
-
-    $token = $response->json('data.accessToken');
-
-    $this->assertNotEmpty($token);
-
-    $product = [
-        'name' => 'Test Product',
-        'description' => 'Test description'
-    ];
-
-    $createProduct = $this->postJson('/api/v1/products', $product, [
-        'Authorization' => "Bearer $token"
-    ]);
-
-    $createProduct->assertStatus(201);
-
-    $this->assertDatabaseHas('products', [
-        'name' => 'Test Product',
-        'description' => 'Test description'
-    ]);
-}
-
-public function test_authenticated_user_can_delete_product()
-{
-    $user = [
-        'name' => 'Test User',
-        'email' => 'testuser@example.com',
-        'password' => 'password',
-        'password_confirmation' => 'password',
-    ];
-
-    $response = $this->postJson('/api/v1/auth/register', $user);
-
-    $response->assertStatus(201);
-
-    $token = $response->json('data.accessToken');
-
-    $this->assertNotEmpty($token);
-
-    $product = [
-        'name' => 'Test Product',
-        'description' => 'Test description'
-    ];
-
-    $createProduct = $this->postJson('/api/v1/products', $product, [
-        'Authorization' => "Bearer $token"
-    ]);
-
-    $createProduct->assertStatus(201);
-
-    $productId = $createProduct->json('data.product_id');
-
-    $deleteProduct = $this->deleteJson("/api/v1/products/{$productId}", [], [
-        'Authorization' => "Bearer $token"
-    ]);
-
-    $deleteProduct->assertStatus(200);
-
-    $this->assertDatabaseMissing('products', [
-        'id' => $productId,
-        'name' => 'Test Product',
-        'description' => 'Test description'
-    ]);
-}
-
-public function test_unauthenticated_user_cannot_delete_product()
-{
-    $user = User::factory()->create();
-    $product = Product::factory()->create(['user_id' => $user->id]);
-
-    $response = $this->deleteJson("/api/v1/products/{$product->id}");
-
-    $response->assertStatus(401);
-
-    $this->assertDatabaseHas('products', [
-        'id' => $product->id,
-        'name' => $product->name,
-        'description' => $product->description
-    ]);
-}
-
-
-    /**
-     * Test that a user cannot delete a non-existent product.
-     */
-    public function test_user_cannot_delete_non_existent_product()
+    private function registerUser()
     {
-        // Register a user
         $user = [
             'name' => 'Test User',
             'email' => 'testuser@example.com',
@@ -115,27 +19,91 @@ public function test_unauthenticated_user_cannot_delete_product()
         ];
 
         $response = $this->postJson('/api/v1/auth/register', $user);
-
-        // Ensure registration was successful
         $response->assertStatus(201);
 
-        // Retrieve the JWT token from the registration response
-        $token = $response->json('data.accessToken');
+        return $response->json('data.accessToken');
+    }
 
+    public function test_authenticated_user_can_create_product()
+    {
+        $token = $this->registerUser();
+        $this->assertNotEmpty($token);
+
+        $product = Product::factory()->make([
+            'user_id' => auth()->id() // This ensures the product is associated with the registered user
+        ])->toArray();
+
+        $createProduct = $this->postJson('/api/v1/products', $product, [
+            'Authorization' => "Bearer $token"
+        ]);
+
+        $createProduct->assertStatus(201);
+
+        $this->assertDatabaseHas('products', [
+            'name' => $product['name'],
+            'description' => $product['description'],
+            'price' => $product['price'] // Use the price from the factory
+        ]);
+    }
+
+    public function test_authenticated_user_can_delete_product()
+    {
+        $token = $this->registerUser();
+        $this->assertNotEmpty($token);
+
+        $product = Product::factory()->create([
+            'user_id' => auth()->id() // This ensures the product is associated with the registered user
+        ]);
+
+        $productId = $product->id;
+
+        $deleteProduct = $this->deleteJson("/api/v1/products/{$productId}", [], [
+            'Authorization' => "Bearer $token"
+        ]);
+
+        $deleteProduct->assertStatus(200);
+
+        $this->assertDatabaseMissing('products', [
+            'id' => $productId,
+            'name' => $product->name,
+            'description' => $product->description,
+            'price' => $product->price // Use the price from the factory
+        ]);
+    }
+
+    public function test_unauthenticated_user_cannot_delete_product()
+    {
+        $user = User::factory()->create();
+        $product = Product::factory()->create([
+            'user_id' => $user->id
+        ]);
+
+        $response = $this->deleteJson("/api/v1/products/{$product->id}");
+
+        $response->assertStatus(401);
+
+        $this->assertDatabaseHas('products', [
+            'id' => $product->id,
+            'name' => $product->name,
+            'description' => $product->description,
+            'price' => $product->price // Use the price from the factory
+        ]);
+    }
+
+    public function test_user_cannot_delete_non_existent_product()
+    {
+        $token = $this->registerUser();
         $this->assertNotEmpty($token);
 
         // Use a non-existent product UUID
-        $nonExistentProductId = '123e4567-e89b-12d3-a456-426614174000';
+        $nonExistentProductId = '123e4567-e89b-12d3-a456-426614174000'; // Ensure this ID does not exist
 
-        // Attempt to delete a non-existent product
         $deleteProduct = $this->deleteJson("/api/v1/products/{$nonExistentProductId}", [], [
             'Authorization' => "Bearer $token"
         ]);
 
-        // Check the status code
         $deleteProduct->assertStatus(404);
 
-        // Assert the appropriate error message is returned
         $deleteProduct->assertJson([
             'message' => 'Product not found',
             'status_code' => 404,

--- a/tests/Unit/ProductDeleteTest.php
+++ b/tests/Unit/ProductDeleteTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Tests\Unit;
 
 use Tests\TestCase;
@@ -9,7 +8,6 @@ class ProductDeleteTest extends TestCase
 {
     use RefreshDatabase;
 
-   
     /**
      * Test that an authenticated user can delete a product.
      */
@@ -113,8 +111,11 @@ class ProductDeleteTest extends TestCase
 
         $this->assertNotEmpty($token);
 
+        // Use a non-existent product UUID
+        $nonExistentProductId = '123e4567-e89b-12d3-a456-426614174000';
+
         // Attempt to delete a non-existent product
-        $deleteProduct = $this->deleteJson('/api/v1/products/999', [], [
+        $deleteProduct = $this->deleteJson("/api/v1/products/{$nonExistentProductId}", [], [
             'Authorization' => "Bearer $token"
         ]);
 

--- a/tests/Unit/ProductDeleteTest.php
+++ b/tests/Unit/ProductDeleteTest.php
@@ -1,3 +1,4 @@
+<?php
 namespace Tests\Unit;
 
 use Tests\TestCase;

--- a/tests/Unit/ProductDeleteTest.php
+++ b/tests/Unit/ProductDeleteTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Product;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class ProductDeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+   
+    /**
+     * Test that an authenticated user can delete a product.
+     */
+    public function test_authenticated_user_can_delete_product()
+    {
+        // Register a user
+        $user = [
+            'name' => 'Test User',
+            'email' => 'testuser@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ];
+
+        $response = $this->postJson('/api/v1/auth/register', $user);
+
+        // Ensure registration was successful
+        $response->assertStatus(201);
+
+        // Retrieve the JWT token from the registration response
+        $token = $response->json('data.accessToken');
+
+        $this->assertNotEmpty($token);
+
+        // Create a product as the authenticated user
+        $product = [
+            'name' => 'Test Product',
+            'description' => 'Test description'
+        ];
+
+        $createProduct = $this->postJson('/api/v1/products', $product, [
+            'Authorization' => "Bearer $token"
+        ]);
+
+        // Check the status code
+        $createProduct->assertStatus(201);
+
+        // Retrieve the created product ID
+        $productId = $createProduct->json('data.product_id');
+
+        // Delete the product
+        $deleteProduct = $this->deleteJson("/api/v1/products/{$productId}", [], [
+            'Authorization' => "Bearer $token"
+        ]);
+
+        // Check the status code
+        $deleteProduct->assertStatus(200);
+
+        // Assert the product was deleted from the database
+        $this->assertDatabaseMissing('products', [
+            'id' => $productId,
+            'name' => 'Test Product',
+            'description' => 'Test description'
+        ]);
+    }
+
+    /**
+     * Test that an unauthenticated user cannot delete a product.
+     */
+    public function test_unauthenticated_user_cannot_delete_product()
+    {
+        // Create a user
+        $user = User::factory()->create();
+
+        // Create a product for the user
+        $product = Product::factory()->create(['user_id' => $user->id]);
+
+        // Attempt to delete the product without authentication
+        $response = $this->deleteJson("/api/v1/products/{$product->id}");
+
+        // Check the status code
+        $response->assertStatus(401);
+
+        // Assert the product still exists in the database
+        $this->assertDatabaseHas('products', [
+            'id' => $product->id,
+            'name' => $product->name,
+            'description' => $product->description
+        ]);
+    }
+
+    /**
+     * Test that a user cannot delete a non-existent product.
+     */
+    public function test_user_cannot_delete_non_existent_product()
+    {
+        // Register a user
+        $user = [
+            'name' => 'Test User',
+            'email' => 'testuser@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ];
+
+        $response = $this->postJson('/api/v1/auth/register', $user);
+
+        // Ensure registration was successful
+        $response->assertStatus(201);
+
+        // Retrieve the JWT token from the registration response
+        $token = $response->json('data.accessToken');
+
+        $this->assertNotEmpty($token);
+
+        // Attempt to delete a non-existent product
+        $deleteProduct = $this->deleteJson('/api/v1/products/999', [], [
+            'Authorization' => "Bearer $token"
+        ]);
+
+        // Check the status code
+        $deleteProduct->assertStatus(404);
+
+        // Assert the appropriate error message is returned
+        $deleteProduct->assertJson([
+            'message' => 'Product not found',
+            'status_code' => 404,
+        ]);
+    }
+}

--- a/tests/Unit/ProductDeleteTest.php
+++ b/tests/Unit/ProductDeleteTest.php
@@ -3,8 +3,6 @@
 namespace Tests\Unit;
 
 use Tests\TestCase;
-use App\Models\User;
-use App\Models\Product;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class ProductDeleteTest extends TestCase

--- a/tests/Unit/ProductDeleteTest.php
+++ b/tests/Unit/ProductDeleteTest.php
@@ -7,6 +7,40 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 class ProductDeleteTest extends TestCase
 {
     use RefreshDatabase;
+    public function test_authenticated_user_can_create_product()
+{
+    $user = [
+        'name' => 'Test User',
+        'email' => 'testuser@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ];
+
+    $response = $this->postJson('/api/v1/auth/register', $user);
+
+    $response->assertStatus(201);
+
+    $token = $response->json('data.accessToken');
+
+    $this->assertNotEmpty($token);
+
+    $product = [
+        'name' => 'Test Product',
+        'description' => 'Test description'
+    ];
+
+    $createProduct = $this->postJson('/api/v1/products', $product, [
+        'Authorization' => "Bearer $token"
+    ]);
+
+    $createProduct->assertStatus(201);
+
+    $this->assertDatabaseHas('products', [
+        'name' => 'Test Product',
+        'description' => 'Test description'
+    ]);
+}
+
 public function test_authenticated_user_can_delete_product()
 {
     $user = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add Product Deletion Endpoint

## Description
This pull request introduces the functionality to delete products through the API. Key changes include:
- Implemented the `destroy` method in `ProductController` to handle product deletion.
- Added a route for the delete endpoint in `api.php`.
- Created a test case to verify the deletion functionality, including scenarios for authenticated users, unauthenticated users, and non-existent products.

## Related Issue (Link to Github issue)
[Issue #77](https://github.com/hngprojects/hng_boilerplate_nestjs/issues/77#issue-2412236965)

## Motivation and Context
The ability to delete products is required to manage the product catalog effectively. This change allows users to remove products they have created, helping to keep the database up to date and relevant.

## How Has This Been Tested?
- Created and ran unit tests for the `destroy` method in `ProductController`.
- Verified that products can be deleted by authenticated users.
- Confirmed that unauthenticated users receive an appropriate error message.
- Checked that attempting to delete non-existent products returns a `404` error with the correct message.

Testing environment:
- PHPUnit for running tests

## Screenshots (if appropriate - Postman, etc):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
