### PR TITLE
[FEAT]: Password Reset Email Link - Backend

### DIFF
--- a/app/Http/Controllers/Api/V1/Auth/ForgetPasswordRequestController.php
+++ b/app/Http/Controllers/Api/V1/Auth/ForgetPasswordRequestController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use App\Traits\HttpResponses;
+use Carbon\Carbon;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\Hash;
+use App\Models\User;
+
+class ForgetPasswordRequestController extends Controller
+{
+    use HttpResponses;
+
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'email' => 'required|email:rfc'
+        ]);
+
+        if ($validator->fails()) {
+            return $this->apiResponse(status: 'Error', message:  $validator->errors(), status_code: 422);
+        }
+
+        $user = User::where('email', $request->email)->first();
+        if (!$user) {
+            return $this->apiResponse(status: 'Error', message:  'User does not exist', status_code: 400);
+        }
+
+        // Create a new token
+        $token_key = Str::random(60);
+        $token = Hash::make($token_key);
+
+        // Store the token in the password_reset_tokens table
+        DB::table('password_reset_tokens')->updateOrInsert(
+            ['email' => $request->email],
+            [
+                'token' => $token,
+                'created_at' => Carbon::now(),
+            ]
+        );
+
+        // Send the reset password email
+        $url = URL::temporarySignedRoute(
+            'password.reset',
+            Carbon::now()->addMinutes(config('auth.passwords.users.expire')),
+            ['token' => $token, 'email' => $request->email]
+        );
+
+        $user->sendPasswordResetNotification($url);
+
+        return $this->apiResponse(status: 'Success', message:  'Password reset link sent');
+
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -11,17 +11,19 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Auth\Passwords\CanResetPassword;
+use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 
-class User extends Authenticatable  implements JWTSubject
+class User extends Authenticatable  implements JWTSubject, CanResetPasswordContract
 {
-    use HasApiTokens, HasFactory, Notifiable, HasUuids;
+    use HasApiTokens, HasFactory, Notifiable, HasUuids, CanResetPassword;
 
     /**
      * The attributes that are mass assignable.
      *
      * @var array<int, string>
      */
-    protected $guarded  = [];
+    protected $guarded  = ['id'];
 
     /**
      * The attributes that should be hidden for serialization.
@@ -175,6 +177,17 @@ class User extends Authenticatable  implements JWTSubject
     public function preferences(): HasMany
     {
         return $this->hasMany(Preference::class);
+    }
+
+    /**
+     * Send the password reset notification.
+     *
+     * @param  string  $token
+     * @return void
+     */
+    public function sendPasswordResetNotification($token)
+    {
+        $this->notify(new \App\Notifications\ResetPasswordNotification($token));
     }
 
 }

--- a/app/Notifications/ResetPasswordNotification.php
+++ b/app/Notifications/ResetPasswordNotification.php
@@ -16,7 +16,6 @@ class ResetPasswordNotification extends Notification implements ShouldQueue
      */
     public function __construct(public $url)
     {
-        $this->onConnection('redis');
     }
 
     /**

--- a/app/Notifications/ResetPasswordNotification.php
+++ b/app/Notifications/ResetPasswordNotification.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ResetPasswordNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(public $url)
+    {
+        $this->onConnection('redis');
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {   
+        return (new MailMessage)
+            ->subject('Reset Password Notification')
+            ->line('You are receiving this email because we received a password reset request for your account.')
+            ->action('Reset Password', $this->url)
+            ->line('If you did not request a password reset, no further action is required.');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'resetUrl' => $this->url,
+        ];
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -9363,5 +9363,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\Api\V1\Testimonial\TestimonialController;
 use App\Http\Controllers\Api\V1\Organisation\OrganisationController;
 use App\Http\Controllers\Api\V1\Organisation\OrganisationRemoveUserController;
 use App\Http\Controllers\Api\V1\Auth\LoginController;
+use App\Http\Controllers\Api\V1\Auth\ForgetPasswordRequestController;
 use App\Http\Middleware\LoginAttempts;
 
 use App\Http\Controllers\Api\V1\JobController;
@@ -40,6 +41,7 @@ Route::prefix('v1')->group(function () {
     Route::post('/auth/register', [AuthController::class, 'store']);
     Route::post('/auth/login', [LoginController::class, 'login']);
     Route::post('/auth/logout', [LoginController::class, 'logout'])->middleware('auth:api');
+    Route::post('/auth/password-reset-email', [ForgetPasswordRequestController::class])->name('password.reset');
     Route::post('/roles', [RoleController::class, 'store']);
 
     Route::apiResource('/users', UserController::class);

--- a/routes/api.php
+++ b/routes/api.php
@@ -41,7 +41,7 @@ Route::prefix('v1')->group(function () {
     Route::post('/auth/register', [AuthController::class, 'store']);
     Route::post('/auth/login', [LoginController::class, 'login']);
     Route::post('/auth/logout', [LoginController::class, 'logout'])->middleware('auth:api');
-    Route::post('/auth/password-reset-email', [ForgetPasswordRequestController::class])->name('password.reset');
+    Route::post('/auth/password-reset-email', ForgetPasswordRequestController::class)->name('password.reset');
     Route::post('/roles', [RoleController::class, 'store']);
 
     Route::apiResource('/users', UserController::class);

--- a/tests/Feature/ForgetPasswordRequestTest.php
+++ b/tests/Feature/ForgetPasswordRequestTest.php
@@ -5,6 +5,13 @@ namespace Tests\Feature;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Hash;
+use App\Models\User;
+use App\Notifications\ResetPasswordNotification;
 
 class ForgetPasswordRequestTest extends TestCase
 {
@@ -12,10 +19,138 @@ class ForgetPasswordRequestTest extends TestCase
     /**
      * A basic feature test example.
      */
-    public function test_example(): void
-    {
-        $response = $this->get('/');
 
-        $response->assertStatus(200);
+    /** @test */
+    public function it_fails_when_email_is_not_provided()
+    {
+        $response = $this->postJson('/api/v1/auth/password-reset-email', []);
+
+        $response->assertStatus(422)
+                ->assertJson([
+                    'status' => 'Error',
+                    'message' => [
+                        'email' => [
+                            'The email field is required.'
+                        ]
+                    ],
+                    'status_code' => 422
+                ]);
+    }
+
+    /** @test */
+    public function it_returns_error_when_user_does_not_exist()
+    {
+        // Create a valid email but without an associated user
+        $response = $this->postJson('/api/v1/auth/password-reset-email', [
+            'email' => 'nonexistentuser@example.com',
+        ]);
+
+        $response->assertStatus(400)
+                ->assertJson([
+                    'status' => 'Error',
+                    'message' => 'User does not exist',
+                    'status_code' => 400
+                ]);
+    }
+
+    /** @test */
+    public function it_returns_error_for_invalid_email_domain()
+    {
+        // Provide an email with a domain that should not be in the database
+        $response = $this->postJson('/api/v1/auth/password-reset-email', [
+            'email' => 'test@invalid-domain.com',
+        ]);
+
+        $response->assertStatus(400)
+                ->assertJson([
+                    'status' => 'Error',
+                    'message' => 'User does not exist',
+                    'status_code' => 400
+                ]);
+    }
+
+    /** @test */
+    public function it_returns_error_for_email_with_invalid_format()
+    {
+        // Provide an invalid email format
+        $response = $this->postJson('/api/v1/auth/password-reset-email', [
+            'email' => 'invalid-email-format',
+        ]);
+
+        $response->assertStatus(422)  // Expect validation error for invalid email format
+                ->assertJson([
+                    'status' => 'Error',
+                    'message' => [
+                        'email' => [
+                            'The email field must be a valid email address.'
+                        ]
+                    ],
+                    'status_code' => 422
+                ]);
+    }
+
+    /** @test */
+    public function it_returns_error_when_email_field_is_empty()
+    {
+        // Provide an empty email field
+        $response = $this->postJson('/api/v1/auth/password-reset-email', [
+            'email' => '',
+        ]);
+
+        $response->assertStatus(422)  // Expect validation error for empty email
+                ->assertJson([
+                    'status' => 'Error',
+                    'message' => [
+                        'email' => [
+                            'The email field is required.'
+                        ]
+                    ],
+                    'status_code' => 422
+                ]);
+    }
+
+    /** @test */
+    public function can_send_password_reset_email()
+    {
+        Notification::fake();
+
+        $user = User::factory()->create([
+            'email' => 'test@example.com',
+        ]);
+
+        $token_key = Str::random(60);
+        $token = Hash::make($token_key);
+
+        $response = $this->postJson('/api/v1/auth/password-reset-email', [
+            'email' => 'test@example.com',
+        ]);
+
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'status' => 'Success',
+                     'message' => 'Password reset link sent',
+                 ]);
+
+        // Assert a notification was sent
+        Notification::assertSentTo(
+            [$user],
+            ResetPasswordNotification::class,
+            function ($notification) use ($token, $user) {
+                // Extract the URL from the notification
+                $url = $notification->toMail($user)->actionUrl;
+
+                // Extract query parameters from the URL
+                $query = parse_url($url, PHP_URL_QUERY);
+                parse_str($query, $params);
+
+                // Verify  email in the URL
+                return $params['email'] === $user->email;
+            }
+        );
+
+        // Check if token is saved in the database
+        $this->assertDatabaseHas('password_reset_tokens', [
+            'email' => 'test@example.com',
+        ]);
     }
 }

--- a/tests/Feature/ForgetPasswordRequestTest.php
+++ b/tests/Feature/ForgetPasswordRequestTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class ForgetPasswordRequestTest extends TestCase
+{
+    use RefreshDatabase;
+    /**
+     * A basic feature test example.
+     */
+    public function test_example(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Unit/ForgetPasswordRequestTest.php
+++ b/tests/Unit/ForgetPasswordRequestTest.php
@@ -21,8 +21,8 @@ class ForgetPasswordRequestTest extends TestCase
 
         $user = User::factory()->create();
         // $url = 'http://example.com/reset-password?token=abc123&email=test@example.com';
-        $token_key = Str::random(60); // Generate a token
-        $token = Hash::make($token_key); // Generate a token
+        $token_key = Str::random(60);
+        $token = Hash::make($token_key);
         $url = URL::temporarySignedRoute(
             'password.reset',
             now()->addMinutes(config('auth.passwords.users.expire')),

--- a/tests/Unit/ForgetPasswordRequestTest.php
+++ b/tests/Unit/ForgetPasswordRequestTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Models\User;
+use Illuminate\Support\Facades\Notification;
+use App\Notifications\ResetPasswordNotification;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class ForgetPasswordRequestTest extends TestCase
+{
+    use RefreshDatabase;
+    /** @test */
+    public function it_sends_password_reset_notification()
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+        // $url = 'http://example.com/reset-password?token=abc123&email=test@example.com';
+        $token_key = Str::random(60); // Generate a token
+        $token = Hash::make($token_key); // Generate a token
+        $url = URL::temporarySignedRoute(
+            'password.reset',
+            now()->addMinutes(config('auth.passwords.users.expire')),
+            ['token' => $token, 'email' => $user->email]
+        );
+
+        $user->sendPasswordResetNotification($url);
+
+        Notification::assertSentTo(
+            [$user], ResetPasswordNotification::class,
+            function ($notification) use ($url) {
+                return $notification->url === $url;
+            }
+        );
+
+         // Simulate a request to the reset URL
+         $response = $this->get($url);
+
+         // Extract query parameters
+         $query = parse_url($url, PHP_URL_QUERY);
+         parse_str($query, $params);
+ 
+         $this->assertEquals($token, $params['token']);
+         $this->assertEquals($user->email, $params['email']);
+    }
+
+    /** @test */
+    public function reset_password_notification_contains_correct_url()
+    {
+        $url = 'http://example.com/reset-password?token=abc123&email=test@example.com';
+        $notification = new ResetPasswordNotification($url);
+
+        $mailMessage = $notification->toMail((object) ['email' => 'test@example.com']);
+
+        $this->assertStringContainsString($url, $mailMessage->actionUrl);
+        $this->assertStringContainsString('Reset Password', $mailMessage->actionText);
+        $this->assertStringContainsString('Reset Password Notification', $mailMessage->subject);
+    }
+}


### PR DESCRIPTION
## Description
Implementing a feature that enables users to request a password reset link sent to their email.
​
## Related Issue (Link to Github issue)
[Isssue 119](https://github.com/hngprojects/hng_boilerplate_php_laravel_web/issues/119)
​
## Motivation and Context
This feature is necessary to allow users to request a password change when they have forgotten their password, enhancing user account security and recovery options.
​
## How Has This Been Tested?
The feature has been tested through various scenarios:
- **Successful Request**: Tested sending a password reset request with a valid email, which triggers an email with a reset link.
- **Invalid Email**: Verified that the system responds correctly when an invalid or non-existent email is provided.
- **Missing Email**: Checked that the system handles requests without an email address appropriately by returning a validation error.
- **Database Check**: Ensured that the reset tokens are correctly stored in the `password_reset_tokens` table.
- **Notification**: Confirmed that the password reset email is sent using Laravel's notification system and contains the correct reset link.

**Testing Environment**:
- **Framework**: Laravel
- **Testing Tools**: PHPUnit, Laravel's built-in test functions, and Postman for API testing.


## Screenshots (if appropriate - Postman, etc):

Success response:
<img width="629" alt="Screenshot 2024-07-24 153838" src="https://github.com/user-attachments/assets/e8e63091-d5a9-4d7c-9089-eb16e3510f2c">

​Error response:
<img width="656" alt="Screenshot 2024-07-24 153911" src="https://github.com/user-attachments/assets/7ff6ae20-1cb4-4211-bef0-ef708aac7599">
​
## Types of changes

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
