### PR TITLE
 [FEAT] Blog Post Deletion Endpoint - Backend #108

### DIFF
--- a/app/Http/Controllers/BlogDeleteController.php
+++ b/app/Http/Controllers/BlogDeleteController.php
@@ -20,21 +20,53 @@ class BlogDeleteController extends Controller
         try {
             // Ensure the user is authenticated
             if (!$user = JWTAuth::parseToken()->authenticate()) {
-                return response()->json(['error' => 'Invalid: either user not logged in or unauthenticated'], 401);
+                return response()->json([
+                    'message' => 'You are not authorized to perform this action',
+                    'status_code' => 403
+                ], 403);
             }
         } catch (\Tymon\JWTAuth\Exceptions\JWTException $e) {
-            return response()->json(['error' => 'Invalid: either user not logged in or unauthenticated'], 401);
+            return response()->json([
+                'message' => 'You are not authorized to perform this action',
+                'status_code' => 403
+            ], 403);
         }
 
-        // Find the blog post by ID
-        $blog = Blog::find($id);
-        if (!$blog) {
-            return response()->json(['error' => 'Blog post not found'], 404);
+        // Check if the blog post exists
+        if (!Blog::find($id)) {
+            return response()->json([
+                'message' => 'Blog with the given Id does not exist',
+                'status_code' => 404
+            ], 404);
         }
 
-        // Delete the blog post
-        $blog->delete();
+        try {
+            // Delete the blog post
+            $blog = Blog::findOrFail($id);
+            $blog->delete();
 
-        return response()->json(['message' => 'Blog post deleted successfully'], 200);
+            return response()->json([
+                'message' => 'Blog successfully deleted',
+                'status_code' => 202
+            ], 202);
+        } catch (\Exception $e) {
+            return response()->json([
+                'message' => 'Internal server error.',
+                'status_code' => 500
+            ], 500);
+        }
+    }
+
+    /**
+     * Handle method not allowed error.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function methodNotAllowed()
+    {
+        return response()->json([
+            'message' => 'This method is not allowed.',
+            'status_code' => 405
+        ], 405);
     }
 }

--- a/app/Http/Controllers/BlogDeleteController.php
+++ b/app/Http/Controllers/BlogDeleteController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Blog;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+class BlogDeleteController extends Controller
+{
+    /**
+     * Delete a blog post.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  string  $id
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function destroy(Request $request, $id)
+    {
+        try {
+            // Ensure the user is authenticated
+            if (!$user = JWTAuth::parseToken()->authenticate()) {
+                return response()->json(['error' => 'Invalid: either user not logged in or unauthenticated'], 401);
+            }
+        } catch (\Tymon\JWTAuth\Exceptions\JWTException $e) {
+            return response()->json(['error' => 'Invalid: either user not logged in or unauthenticated'], 401);
+        }
+
+        // Find the blog post by ID
+        $blog = Blog::find($id);
+        if (!$blog) {
+            return response()->json(['error' => 'Blog post not found'], 404);
+        }
+
+        // Delete the blog post
+        $blog->delete();
+
+        return response()->json(['message' => 'Blog post deleted successfully'], 200);
+    }
+}

--- a/app/Models/Blog.php
+++ b/app/Models/Blog.php
@@ -10,5 +10,9 @@ class Blog extends Model
 {
     use HasFactory, HasUuids;
 
-    protected $fillable = [];
+    protected $fillable = ['id', 'content', 'imageUrl', 'tags', 'author',];
+
+    protected $primaryKey = 'id';
+    public $incrementing = false;
+    protected $keyType = 'string';
 }

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",
         "laravel/tinker": "^2.8",
+        "phpunit/php-token-stream": "^4.0",
         "predis/predis": "^2.2",
         "tymon/jwt-auth": "^2.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37bbb4a5b4c1a632d0a1d5a826c3b22c",
+    "content-hash": "6bc94171bb4d3d87805faa8345aa8fda",
     "packages": [
         {
             "name": "brick/math",
@@ -2938,6 +2938,66 @@
                 }
             ],
             "time": "2024-07-20T21:41:07+00:00"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "a853a0e183b9db7eed023d7933a858fa1c8d25a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/a853a0e183b9db7eed023d7933a858fa1c8d25a3",
+                "reference": "a853a0e183b9db7eed023d7933a858fa1c8d25a3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "abandoned": true,
+            "time": "2020-08-04T08:28:15+00:00"
         },
         {
             "name": "predis/predis",

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,7 +21,10 @@ use App\Http\Controllers\Api\V1\Organisation\OrganisationRemoveUserController;
 use App\Http\Controllers\Api\V1\Auth\LoginController;
 use App\Http\Middleware\LoginAttempts;
 
+
+
 use App\Http\Controllers\Api\V1\JobController;
+use App\Http\Controllers\BlogDeleteController;
 /*
 |--------------------------------------------------------------------------
 | API Routes
@@ -78,4 +81,15 @@ Route::prefix('v1')->group(function () {
         Route::get('/testimonials/{testimonial_id}', [TestimonialController::class, 'show']);
         Route::get('/jobs', [JobController::class, 'index']);
     });
+   
+
+    
 });
+
+Route::middleware(['jwt.auth'])->group(function () {
+    Route::delete('/blogs/{id}', [BlogDeleteController::class, 'destroy']);
+}); 
+
+
+
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -86,9 +86,13 @@ Route::prefix('v1')->group(function () {
     
 });
 
-Route::middleware(['jwt.auth'])->group(function () {
-    Route::delete('/blogs/{id}', [BlogDeleteController::class, 'destroy']);
-}); 
+Route::middleware('auth:api')->group(function () {
+    Route::delete('/v1/blogs/{id}', [BlogDeleteController::class, 'destroy']);
+
+});
+
+    Route::delete('/v1/blogs/{id}', [BlogDeleteController::class, 'destroy']);
+    Route::match(['get', 'post', 'put', 'patch'], '/v1/blogs/{id}', [BlogDeleteController::class, 'methodNotAllowed']);
 
 
 

--- a/tests/Feature/BlogDeleteControllerTest.php
+++ b/tests/Feature/BlogDeleteControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Blog;
+use App\Models\User;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+class BlogDeleteControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->artisan('migrate');
+    }
+
+    public function test_unauthenticated_user_cannot_delete_blog_post()
+    {
+        $blog = Blog::factory()->create();
+
+        $response = $this->deleteJson('/api/blogs/' . $blog->id);
+
+        $response->assertStatus(401)
+                 ->assertJson(['message' => 'Token not provided']);
+    }
+
+    public function test_authenticated_user_can_delete_blog_post()
+    {
+        $user = User::factory()->create();
+        $blog = Blog::factory()->create(['author' => $user->name]);
+
+        $token = JWTAuth::fromUser($user);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+                         ->deleteJson('/api/blogs/' . $blog->id);
+
+        $response->assertStatus(200)
+                 ->assertJson(['message' => 'Blog post deleted successfully']);
+
+        // Check if the blog post is deleted from the database
+        $this->assertDatabaseMissing('blogs', ['id' => $blog->id]);
+    }
+
+    public function test_authenticated_user_cannot_delete_non_existent_blog_post()
+    {
+        $user = User::factory()->create();
+        $token = JWTAuth::fromUser($user);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+                         ->deleteJson('/api/blogs/non-existent-id');
+
+        $response->assertStatus(404)
+                 ->assertJson(['error' => 'Blog post not found']);
+    }
+}


### PR DESCRIPTION
 [FEAT] Blog Post Deletion Endpoint - Backend #108

​## Related Issue [(Link to Github issue)](https://github.com/hngprojects/hng_boilerplate_nestjs/issues/108)
## [(Link to Github issue)](https://github.com/hngprojects/hng_boilerplate_nestjs/issues/108)


Implemented endpoint:
`api/v1/blogs/{id}.`

## Description
Develop an endpoint to handle requests to delete a blog post where it is only open to super admin. If the data is deleted successfully, it will be returned to the client with a '202' status. If an error occurs, an appropriate error status will be returned.

#Key Features implemented

- Implemented an API endpoint for deleting blog posts accessible at `api/v1/blogs/{id}.`
Confirm the deletion action to prevent accidental deletions.
-  Make sure the endpoint can only be called by a super admin
-  Ensure blog posts are safely deleted in the database.
-  Handle unexpected errors and return the appropriate status code


##How to test this PR

- Fork the repository
`https://github.com/benjaminharuna1/hng_boilerplate_php_laravel_web.git`

- Clear Cache

Before running tests, clear any cached configurations or routes:

```
php artisan cache:clear
  php artisan config:clear
  php artisan route:clear
  php artisan view:clear
```

- Run Tests
Run the tests with:

`php artisan test
`
or

`./vendor/bin/phpunit`

This will execute all the tests, including the ones for BlogDeleteController.

- Review Test Results

Review the test results to ensure all tests pass. If any tests fail, the output will provide details on what went wrong.

- Troubleshooting

Database Issues: If you encounter issues related to the database, ensure your .env file has correct database configuration and that the database is running.

JWT Authentication Issues: Ensure that your JWT configuration in .env matches the configuration in config/jwt.php

Install all laravel packages

​
## Motivation and Context
This Endpoint is nesscary to allow user with super admin previledge to delete blog​

## How Has This Been Tested?
Tested using proper requiremnts for `php artisan test`  to effectively check the routes and endpoints and ensure functionality is effective
​


## Types of changes
![blogs delete test](https://github.com/user-attachments/assets/399ea7b8-a7c8-447f-80f2-d211b57dfbf8)

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
