### PR TITLE
[FEAT] Implement Organization Deletion

### DIFF
--- a/app/Http/Controllers/Api/V1/Organisation/OrganisationController.php
+++ b/app/Http/Controllers/Api/V1/Organisation/OrganisationController.php
@@ -123,10 +123,22 @@ class OrganisationController extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(string $id)
+    public function destroy($org_id)
     {
-        //
+        $user = auth('api')->user();
+        if(!$user) return ResponseHelper::response("Authentication failed", 401, null);
+        $organisation = Organisation::find($org_id);
+        if(!$organisation) return ResponseHelper::response("Organisation not found", 404, null);
+        if(!$organisation->users->contains($user->id)) return ResponseHelper::response("You are not authorised to perform this action", 403, null);
+        try {
+            // Soft delete the org
+            $organisation->delete();
+            return ResponseHelper::response("Organisation deleted successfully", 200, null);
+        }catch (\Exception $e) {
+            return ResponseHelper::response("Client error", 400, null);
+        }
     }
+    
     public function removeUser(Request $request, $org_id, $user_id)
     {
         $organization = Organisation::findOrFail($org_id);

--- a/routes/api.php
+++ b/routes/api.php
@@ -81,6 +81,7 @@ Route::prefix('v1')->group(function () {
         // Organisations
         Route::post('/organisations', [OrganisationController::class, 'store']);
         Route::get('/organisations', [OrganisationController::class, 'index']);
+        Route::delete('/organisations/{org_id}', [OrganisationController::class, 'destroy']);
         Route::delete('/organisations/{org_id}/users/{user_id}', [OrganisationController::class, 'removeUser']);
         Route::get('/organisations/{organisation}/members', [OrganizationMemberController::class, 'index']);
 


### PR DESCRIPTION
Description
Create an API endpoint to handle the deletion of an organization. This endpoint will validate the organization ID and update the specified organization deleted attribute to true in the database upon successful validation.

Acceptance Criteria
The endpoint should be accessible at /api/v1/organizations/:org_id.
The endpoint should accept HTTP DELETE requests.
The endpoint should be protected and require authentication.
The endpoint should check that the user hitting the endpoint is the owner of the organization.
Requests to the endpoint must include a valid authentication token in the Authorization header. Authorization: Bearer <token>
Upon successful validation of the organization ID, the organization should be marked as deleted by changing deleted attribute in the database to true.
All related data to the organization should remain intact.
Data Validation and Sanitization:
The API should validate the request to ensure the organization ID is present and valid.
The organization ID should be checked for correctness and validity (e.g., it exists in the system).
The API should verify that the authenticated user is the owner of the organization.
Request
Endpoint DELETE /api/v1/organizations/:org_id

Request example:
DELETE /api/v1/organizations/:org_id
Content-Type: application/json
Authorization: Bearer <token>
Expected Successful Response:
204 No Content status code

Expected Error Response:
{
  "message": "Failed to delete organization",
  "error": "Invalid organization ID format",
  "status_code": 400
}
{
  "message": "Failed to delete organization",
  "error": "Invalid organization ID",
  "status_code": 404
}
{
  "message": "Failed to delete organization",
  "error": "User not authorized to delete this organization",
  "status_code": 401
}
Purpose
Provides a backend service to handle the deletion of organizations, ensuring the organization ID is valid and setting the organization deleted attribute to true in the database.

Tasks
 Develop server-side logic to handle organization deletion requests.
 Validate and sanitize incoming organization ID data.
 Validate the user deleting the organization is the owner.
 Change the specified organizationdeleted attribute upon successful validation to true in the database.
 Keep all related data of the specified organization intact.
Testing
1 - Write unit tests to ensure the organization deletion endpoint validates input correctly and removes the organization from the system.
2 - Test various scenarios for submitting the organization ID (e.g., valid ID, non-existent ID, malformed ID, etc.).

