### PR TITLE
[feat] delete user testimonial

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -94,5 +94,7 @@ Route::prefix('v1')->group(function () {
         Route::get('/user/export/{format}', [ExportUserController::class, 'export']);
     });
 
+    Route::delete('/testimonials/{testimonial_id}', [TestimonialController::class, 'destroy'])->middleware('auth.jwt');
+
     Route::middleware(['auth:api', 'admin'])->get('/customers', [CustomerController::class, 'index']);
 });

--- a/tests/Feature/DeleteTestimonialTest.php
+++ b/tests/Feature/DeleteTestimonialTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+use App\Models\User;
+use App\Models\Testimonial;
+use Illuminate\Http\Response;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+class DeleteTestimonialTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function getAuthenticatedUser()
+    {
+        $user = User::factory()->create();
+
+        $token = JWTAuth::attempt(['email' => $user->email, 'password' => 'password']);
+
+        return [$user, $token];
+    }
+
+    /**
+     * Test deleting a testimonial as an authenticated user.
+     *
+     * @return void
+     */
+    public function test_delete_testimonial()
+    {
+        // Login
+        [$user, $token] = $this->getAuthenticatedUser();
+
+        // Create a testimonial for the user
+        $testimonial = Testimonial::factory()->create(['user_id' => $user->id]);
+
+        // Authenticate the user and send a DELTE request to delete the testimonial
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+        ])->deleteJson('/api/v1/testimonials/' . $testimonial->id);
+
+        // Assert the response status and structure
+        $response->assertStatus(Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * Test deleting a testimonial as an unauthenticated user.
+     *
+     * @return void
+     */
+    public function test_delete_testimonial_unauthenticated()
+    {
+        // Create a testimonial
+        $testimonial = Testimonial::factory()->create();
+
+        // Send a DELETE request without authentication
+        $response = $this->deleteJson('/api/v1/testimonials/' . $testimonial->id);
+
+        // Assert the response status
+        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * Test deleting a testimonial that does not belong to the user.
+     *
+     * @return void
+     */
+    public function test_delete_testimonial_not_owned_by_user()
+    {
+        // Create two users
+        [$user1, $token1] = $this->getAuthenticatedUser();
+        [$user2, $token2] = $this->getAuthenticatedUser();
+
+        // Create a testimonial for the second user
+        $testimonial2 = Testimonial::factory()->create(['user_id' => $user2->id]);
+
+        // Authenticate the first user and send a DELETE request to delete the testimonial
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token1,
+        ])->deleteJson(
+            '/api/v1/testimonials/' . $testimonial2->id
+        );
+
+        // Assert the response status
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+    /**
+     * Test deleting a testimonial that does not exist.
+     *
+     * @return void
+     */
+    public function test_delete_testimonial_not_exist()
+    {
+        // Login
+        [$user, $token] = $this->getAuthenticatedUser();
+
+        // Authenticate the user and send a DELTE request to delete the testimonial
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+        ])->deleteJson('/api/v1/testimonials/1');
+
+        // Assert the response status and structure
+        $response->assertStatus(Response::HTTP_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
DELETE `api/v1/testimonials/{testimonial_id}`
​
## Description
<!--- Describe your changes in detail -->
Create an API endpoint to manage the deletion of testimonials. This API will verify the validity of the testimonial_id.
​
## Related Issue (Link to Github issue)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Issue 238 on Nestjs](https://github.com/hngprojects/hng_boilerplate_nestjs/issues/238)
​
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If a user wishes to remove their testimonial from the website
​
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with automated tests and Postman
​
## Screenshots (if appropriate - Postman, etc):
​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
