### PR TITLE
[fix]: remove protection for documentation

### DIFF
--- a/config/swagger-ui.php
+++ b/config/swagger-ui.php
@@ -27,7 +27,7 @@ return [
              */
             'middleware' => [
                 'web',
-                EnsureUserIsAuthorized::class,
+//                EnsureUserIsAuthorized::class,
             ],
 
             /*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​
## Description
Allow anyone access documentation
​
## Related Issue (Link to Github issue: Bug Fix No Link)

​
## Motivation and Context
To allow anyone access documnetation
​
## How Has This Been Tested?
on browser
​
## Screenshots (if appropriate - Postman, etc):
​
<img width="1390" alt="Screenshot 2024-07-25 at 10 30 36" src="https://github.com/user-attachments/assets/9e1e418d-34c3-431c-bbd6-7c536cf6b2ce">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
