### PR TITLE
feat: add notification read and notification read all endpoint and documentation

### DIFF
--- a/app/Http/Controllers/UserNotificationController.php
+++ b/app/Http/Controllers/UserNotificationController.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Notification;
+use App\Models\UserNotification;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
+
+class UserNotificationController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, $notificationId)
+    {
+        $request->validate([
+            'is_read' => 'boolean|required'
+        ]);
+        try {
+            $notification = UserNotification::query()->findOrFail($notificationId);
+            $notification->status = $request->is_read ? 'read' : 'unread';
+            $notification->save();
+
+            return response()->json([
+                'status' => 'success',
+                'message' => 'notification cleared successfully',
+                'status_code' => Response::HTTP_OK,
+                'data' => $notification,
+            ], Response::HTTP_OK);
+
+        } catch (ModelNotFoundException $exception) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'notification not found',
+                'status_code' => Response::HTTP_NOT_FOUND,
+            ], Response::HTTP_NOT_FOUND);
+        } catch (\Exception $exception) {
+            Log::error($exception->getMessage());
+            return response()->json([
+                'status' => 'error',
+                'message' => 'something went wrong',
+                'status_code' => Response::HTTP_INTERNAL_SERVER_ERROR,
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy()
+    {
+        try {
+
+            UserNotification::query()->where([
+                ['user_id', auth()->id()],
+                ['status', 'unread']
+            ])->update([
+                'status' => 'read'
+            ]);
+
+            return response()->json([
+                'status' => 'success',
+                'message' => 'notifications cleared successfully',
+                'status_code' => Response::HTTP_OK,
+                'data' => UserNotification::query()->where('user_id', auth()->id())->get(),
+            ], Response::HTTP_OK);
+
+        } catch (ModelNotFoundException $exception) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'notifications not found',
+                'status_code' => Response::HTTP_NOT_FOUND,
+            ], Response::HTTP_NOT_FOUND);
+        } catch (\Exception $exception) {
+            Log::error($exception->getMessage());
+            return response()->json([
+                'status' => 'error',
+                'message' => 'something went wrong',
+                'status_code' => Response::HTTP_INTERNAL_SERVER_ERROR,
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/database/factories/NotificationFactory.php
+++ b/database/factories/NotificationFactory.php
@@ -17,7 +17,9 @@ class NotificationFactory extends Factory
     public function definition(): array
     {
         return [
-            //
+            'title' => $this->faker->sentence(),
+            'type' => $this->faker->randomElement(['email', 'push']),
+            'message' => $this->faker->paragraph(),
         ];
     }
 }

--- a/database/factories/UserNotificationFactory.php
+++ b/database/factories/UserNotificationFactory.php
@@ -2,6 +2,8 @@
 
 namespace Database\Factories;
 
+use App\Models\Notification;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -17,7 +19,9 @@ class UserNotificationFactory extends Factory
     public function definition(): array
     {
         return [
-            //
+            'user_id' => User::factory(),
+            'notification_id' => Notification::factory(),
+            'status' => $this->faker->randomElement(['unread']),
         ];
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -66,7 +66,8 @@ class DatabaseSeeder extends Seeder
             ProductSeeder::class,
             ProductVariantSeeder::class,
             ProductVariantSizeSeeder::class,
-            FaqSeeder::class
+            FaqSeeder::class,
+            UserNotificationSeeder::class,
         ]);
 
     }

--- a/database/seeders/UserNotificationSeeder.php
+++ b/database/seeders/UserNotificationSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\UserNotification;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -12,6 +13,6 @@ class UserNotificationSeeder extends Seeder
      */
     public function run(): void
     {
-        //
+        UserNotification::factory()->count(5)->create();
     }
 }

--- a/resources/docs/documentation.json
+++ b/resources/docs/documentation.json
@@ -3121,6 +3121,211 @@
           }
         }
       }
+    },
+    "/api/v1/notifitions/notification_id}": {
+      "patch": {
+          "tags": ["User Notifications"],
+          "summary": "Clear single notification",
+          "requestBody": {
+              "required": true,
+              "content": {
+                  "application/json" : {
+                      "schema": {
+                          "type": "array",
+                          "items": {
+                              "properties": {
+                                  "is_read": {
+                                      "type": "boolean",
+                                      "example": "1 or 0"
+                                  }
+                              }
+                          }
+                      }
+                  }
+              }
+          },
+          "responses": {
+              "200": {
+                  "description": "Successful response",
+                  "content": {
+                      "application/json": {
+                          "schema": {
+                              "type": "array",
+                              "items": {
+                                  "properties": {
+                                      "status": {
+                                          "type": "string",
+                                          "example": "success"
+                                      },
+                                      "message": {
+                                          "type": "string",
+                                          "example": "notification cleared successfully"
+                                      },
+                                      "data": {
+                                          "type": "object",
+                                          "example": {
+                                              "id": "xxxx-xxxx-xxxx-xxxx",
+                                              "user_id": "xxxx-xxxx-xxxx-xxxx",
+                                              "notification_id": "xxxx-xxxx-xxxx-xxxx",
+                                              "status": "read"
+                                          }
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                  }
+              },
+              "404" : {
+                  "description": "Notification not found",
+                  "content": {
+                      "application/json": {
+                          "schema": {
+                              "type": "object",
+                              "properties": {
+                                  "status": {
+                                      "example": "error"
+                                  },
+                                  "message":  {
+                                      "example": "not found"
+                                  },
+                                  "status_code":  {
+                                      "example": 404
+                                  }
+                              }
+                          }
+                      }
+                  }
+              },
+              "422" : {
+                  "description": "Validation Errors",
+                  "content": {
+                      "application/json": {
+                          "schema": {
+                              "type": "object",
+                              "properties": {
+                                  "message":  {
+                                      "example": "The is read field must be true or false."
+                                  },
+                                  "errors":  {
+                                      "type": "array",
+                                      "items": {
+                                          "properties": {
+                                              "is_read": {
+                                                  "example": "The is read field must be true or false."
+                                              }
+                                          }
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                  }
+              },
+              "500" : {
+                  "description": "Notification not found",
+                  "content": {
+                      "application/json": {
+                          "schema": {
+                              "type": "object",
+                              "properties": {
+                                  "status": {
+                                      "example": "error"
+                                  },
+                                  "message":  {
+                                      "example": "something went wrong"
+                                  },
+                                  "status_code":  {
+                                      "example": 500
+                                  }
+                              }
+                          }
+                      }
+                  }
+              }
+          }
+      }
+    },
+    "/api/v1/notifitions": {
+        "delete": {
+            "tags": ["User Notifications"],
+            "summary": "Clear All notification",
+            "responses": {
+                "200": {
+                    "description": "Successful response",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "all notification cleared successfully"
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "example": {
+                                                "id": "xxxx-xxxx-xxxx-xxxx",
+                                                "user_id": "xxxx-xxxx-xxxx-xxxx",
+                                                "notification_id": "xxxx-xxxx-xxxx-xxxx",
+                                                "status": "read"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "404" : {
+                    "description": "Notification not found",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "status": {
+                                        "example": "error"
+                                    },
+                                    "message":  {
+                                        "example": "not found"
+                                    },
+                                    "status_code":  {
+                                        "example": 404
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "500" : {
+                    "description": "Notification not found",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "status": {
+                                        "example": "error"
+                                    },
+                                    "message":  {
+                                        "example": "something went wrong"
+                                    },
+                                    "status_code":  {
+                                        "example": 500
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
   },
   "components": {

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\V1\Admin\BlogCategoriesController;
 use App\Http\Controllers\Api\V1\Admin\FaqController;
+use App\Http\Controllers\UserNotificationController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\V1\JobController;
@@ -210,6 +211,11 @@ Route::prefix('v1')->group(function () {
 
     // Notification settings
     Route::patch('/notification-settings/{user_id}', [NotificationPreferenceController::class, 'update']);
+
+    // User Notification
+    Route::patch('/notifications/{notification}', [UserNotificationController::class, 'update']);
+    Route::delete('/notifications', [UserNotificationController::class, 'destroy']);
+
 });
 
 

--- a/tests/Feature/UserNotificationTest.php
+++ b/tests/Feature/UserNotificationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\UserNotification;
+use Database\Factories\UserFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Response;
+use Tests\TestCase;
+
+class UserNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_clear_single_notification()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+        $userNotification = UserNotification::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $response = $this->patch("/api/v1/notifications/{$userNotification->id}", [
+            'is_read' => true,
+        ]);
+        $response->assertSuccessful();
+        $this->assertDatabaseHas('user_notifications', [
+            'id' => $userNotification->id,
+            'status' => 'read',
+        ]);
+    }
+
+    public function test_user_can_clear_all_notifications()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+        UserNotification::factory()->count(2)->create([
+            'user_id' => $user->id,
+            'status' => 'unread',
+        ]);
+        $response = $this->delete("/api/v1/notifications");
+        $response->assertSuccessful();
+        $response->assertJsonCount(2, 'data');
+    }
+
+    public function test_validation_trap_is_read_not_passed()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+        $userNotification = UserNotification::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $response = $this->patch("/api/v1/notifications/{$userNotification->id}", [], [
+            'accept' => 'application/json',
+        ]);
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $response->assertJsonValidationErrors(['is_read']);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​
## Description
endpoint to allow users mark single notification as read or mark all notifications as read
​
## Related Issue https://github.com/hngprojects/hng_boilerplate_php_laravel_web/issues/307
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
​
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
​
## How Has This Been Tested?
phpunit and postman
​
## Screenshots (if appropriate - Postman, etc):
<img width="797" alt="Screenshot 2024-07-30 at 19 14 38" src="https://github.com/user-attachments/assets/012be90f-00b6-49dd-8627-122c940031c5">
<img width="771" alt="Screenshot 2024-07-30 at 19 14 31" src="https://github.com/user-attachments/assets/b931ed4b-1575-4678-8cb7-880517a3b8d9">

​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
