### PR TITLE
fix: Organization endpoint update

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -141,12 +141,12 @@ Route::prefix('v1')->group(function () {
 
 
         // Organisations
-        Route::post('/organisations', [OrganisationController::class, 'store']);
-        Route::get('/organisations', [OrganisationController::class, 'index']);
-        Route::put('/organisations/{org_id}', [OrganisationController::class, 'update']);
-        Route::delete('/organisations/{org_id}', [OrganisationController::class, 'destroy']);
-        Route::delete('/organisations/{org_id}/users/{user_id}', [OrganisationController::class, 'removeUser']);
-        Route::get('/organisations/{organisation}/members', [OrganizationMemberController::class, 'index']);
+        Route::post('/organizations', [OrganisationController::class, 'store']);
+        Route::get('/organizations', [OrganisationController::class, 'index']);
+        Route::put('/organizations/{org_id}', [OrganisationController::class, 'update']);
+        Route::delete('/organizations/{org_id}', [OrganisationController::class, 'destroy']);
+        Route::delete('/organizations/{org_id}/users/{user_id}', [OrganisationController::class, 'removeUser']);
+        Route::get('/organizations/{organisation}/users', [OrganizationMemberController::class, 'index']);
 
         // members
         Route::get('/members/{org_id}/search', [OrganizationMemberController::class, 'searchMembers']);

--- a/tests/Feature/InvitationTest.php
+++ b/tests/Feature/InvitationTest.php
@@ -38,7 +38,7 @@ class InvitationTest extends TestCase
         $this->accessToken = $loginResponse['data']['access_token'];
 
         // Create an organisation
-        $orgResponse = $this->postJson('/api/v1/organisations', [
+        $orgResponse = $this->postJson('/api/v1/organizations', [
             'name' => 'test organisations',
             'description' => 'test org description',
             'email' => 'test.main.org@example.com',

--- a/tests/Feature/OrganisationRemoveUserTest.php
+++ b/tests/Feature/OrganisationRemoveUserTest.php
@@ -19,7 +19,7 @@ class OrganisationRemoveUserTest extends TestCase
     /** @test */
     public function it_test_unauthenticated_user_cannot_remove_user()
     {
-        $response = $this->delete('/api/v1/organisations/44572ad3-2efe-463c-9531-8b879ef2bfa5/users/44572ad3-2efe-463c-9531-8b879ef2bfa5', [], [
+        $response = $this->delete('/api/v1/organizations/44572ad3-2efe-463c-9531-8b879ef2bfa5/users/44572ad3-2efe-463c-9531-8b879ef2bfa5', [], [
             'accept' => 'application/json',
         ]);
         $response->assertStatus(401)
@@ -38,7 +38,7 @@ class OrganisationRemoveUserTest extends TestCase
         $token = JWTAuth::fromUser($anotherUser);
 
         $response = $this->withHeaders(['Authorization' => "Bearer $token"])
-            ->deleteJson("/api/v1/organisations/{$organization->org_id}/users/{$user->id}");
+            ->deleteJson("/api/v1/organizations/{$organization->org_id}/users/{$user->id}");
 
         $response->assertStatus(403)
             ->assertJson([
@@ -61,7 +61,7 @@ class OrganisationRemoveUserTest extends TestCase
         $token = JWTAuth::fromUser($superadmin);
 
         $response = $this->withHeaders(['Authorization' => "Bearer $token"])
-            ->deleteJson("/api/v1/organisations/{$org->org_id}/users/{$user->id}");
+            ->deleteJson("/api/v1/organizations/{$org->org_id}/users/{$user->id}");
 
         $response->assertStatus(200)
             ->assertJson([
@@ -89,7 +89,7 @@ class OrganisationRemoveUserTest extends TestCase
         $token = JWTAuth::fromUser($superadmin);
 
         $response = $this->withHeaders(['Authorization' => "Bearer $token"])
-            ->deleteJson("/api/v1/organisations/{$org->org_id}/users/{$user->id}");
+            ->deleteJson("/api/v1/organizations/{$org->org_id}/users/{$user->id}");
 
         $response->assertStatus(200)
             ->assertJson([
@@ -123,7 +123,7 @@ class OrganisationRemoveUserTest extends TestCase
         $token = JWTAuth::fromUser($admin);
 
         $response = $this->withHeaders(['Authorization' => "Bearer $token"])
-            ->delete("/api/v1/organisations/{$org->org_id}/users/{$user->id}");
+            ->delete("/api/v1/organizations/{$org->org_id}/users/{$user->id}");
 
         $response->assertStatus(200)
             ->assertJson([
@@ -145,7 +145,7 @@ class OrganisationRemoveUserTest extends TestCase
         $nonExistentUserId = '44572ad3-2efe-463c-9531-8b879ef2bfa5';
 
         $response = $this->withHeaders(['Authorization' => "Bearer $token"])
-            ->delete("/api/v1/organisations/{$organization->org_id}/users/{$nonExistentUserId}");
+            ->delete("/api/v1/organizations/{$organization->org_id}/users/{$nonExistentUserId}");
 
         $response->assertStatus(404)
             ->assertJson([

--- a/tests/Feature/OrganisationTest.php
+++ b/tests/Feature/OrganisationTest.php
@@ -20,7 +20,7 @@ class OrganisationTest extends TestCase
         $user = User::factory()->create();
         $this->actingAs($user);
 
-        $response = $this->post('/api/v1/organisations', [
+        $response = $this->post('/api/v1/organizations', [
             "email" => "mark.essienm@gmail.co.uk",
             "name" => "Ruxy Now Organisation",
             "description" => "With description like a big man",
@@ -42,7 +42,7 @@ class OrganisationTest extends TestCase
 
     public function test_unauthenticated_user_cannot_access_endpoint()
     {
-        $response = $this->getJson('/api/v1/organisations');
+        $response = $this->getJson('/api/v1/organizations');
 
         $response->assertStatus(401)
             ->assertJson([
@@ -59,7 +59,7 @@ class OrganisationTest extends TestCase
         $token = JWTAuth::fromUser($user);
 
         $response = $this->withHeader('Authorization', "Bearer $token")
-            ->getJson('/api/v1/organisations', ['accept' => 'application/json']);
+            ->getJson('/api/v1/organizations', ['accept' => 'application/json']);
 
         $response->assertStatus(200)
             ->assertJsonStructure([
@@ -100,7 +100,7 @@ class OrganisationTest extends TestCase
 
         $token = JWTAuth::fromUser($user);
         $response = $this->withHeader('Authorization', "Bearer $token")
-            ->getJson('/api/v1/organisations');
+            ->getJson('/api/v1/organizations');
 
         $response->assertStatus(200)
             ->assertJson([
@@ -122,7 +122,7 @@ class OrganisationTest extends TestCase
 
         $token = JWTAuth::attempt(['email' => $user1->email, 'password' => 'password']);
         $response = $this->withHeader('Authorization', "Bearer $token")
-            ->getJson('/api/v1/organisations');
+            ->getJson('/api/v1/organizations');
 
         $response->assertStatus(200)
             ->assertJson([

--- a/tests/Feature/OrganizationMemberControllerTest.php
+++ b/tests/Feature/OrganizationMemberControllerTest.php
@@ -48,7 +48,7 @@ class OrganizationMemberControllerTest extends TestCase
         $token = $response->json('data.access_token');
 
         // Create an organization
-        $response = $this->postJson('/api/v1/organisations', [
+        $response = $this->postJson('/api/v1/organizations', [
             'name' => 'Example Organization',
             'description' => 'This is an example organization description.',
             'email' => 'example@example.com',
@@ -65,7 +65,7 @@ class OrganizationMemberControllerTest extends TestCase
         $organisation = $response->json('data.org_id');
 
         // Fetch members with valid organization ID
-        $response = $this->getJson("/api/v1/organisations/{$organisation}/members?page=1&page_size=10", [
+        $response = $this->getJson("/api/v1/organizations/{$organisation}/users?page=1&page_size=10", [
             'Authorization' => 'Bearer ' . $token
         ]);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​
## Description
I changed the spelling of the implemented organization API endpoint from 'organisation' to 'organization', and also updated the spelling in the test files. This change only affects the organization endpoint related to settings (Profile + Org).
​
## Related Issue (Link to Github issue)
[LINK]()
​
## Motivation and Context
All team leads agreed on the specific spelling to be used, so I obliged.
​
## How Has This Been Tested?
Yes, it was tested using Postman and PHPunit.
​
## Screenshots (Postman test):
![get all user in an org](https://github.com/user-attachments/assets/2f7058e1-4980-4227-ba8d-3103c8f38a30)
![updated organization with id](https://github.com/user-attachments/assets/d343292d-b31a-42ab-8f77-8a49885e458a)
![get all organization](https://github.com/user-attachments/assets/5951f086-e0e7-4969-b897-f1324adcf209)
![create organization](https://github.com/user-attachments/assets/91ff88fb-e11c-48ae-990a-92bc36447bf2)

​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
