### PR TITLE
fix: facebook login

### DIFF
--- a/app/Http/Controllers/Api/V1/Auth/SocialAuthController.php
+++ b/app/Http/Controllers/Api/V1/Auth/SocialAuthController.php
@@ -22,20 +22,17 @@ class SocialAuthController extends Controller
     {
         $googleUser = Socialite::driver('google')->stateless()->user();
 
-        // Create or update the user
         $user = User::updateOrCreate(
             ['email' => $googleUser->email],
             [
-                'password' => Hash::make(Str::password(12)), // Use a random password
-                'social_id' => $googleUser->id, // Save Google ID for future reference
-                'is_verified' => true, // Assuming verified on successful social login
+                'password' => Hash::make(Str::password(12)),
+                'social_id' => $googleUser->id,
+                'is_verified' => true,
                 'signup_type' => 'Google',
                 'is_active' => true,
             ]
         );
 
-        // dd($user->profile);
-        // If profile is a separate model, ensure it is created or updated accordingly
         if ($user->profile) {
             $user->profile->update([
                 'first_name' => $googleUser->user['given_name'],
@@ -43,7 +40,6 @@ class SocialAuthController extends Controller
                 'avatar_url' => $googleUser->attributes['avatar_original'],
             ]);
         } else {
-            // Create a profile if it does not exist
             $user->profile()->create([
                 'first_name' => $googleUser->user['given_name'],
                 'last_name' => $googleUser->user['family_name'],
@@ -51,10 +47,8 @@ class SocialAuthController extends Controller
             ]);
         }
 
-        // Generate JWT token
         $token = JWTAuth::fromUser($user);
 
-        // Prepare the response data
         $response = [
             'status' => 'success',
             'message' => 'User successfully authenticated',
@@ -79,51 +73,57 @@ class SocialAuthController extends Controller
     {
         $facebookUser = Socialite::driver('facebook')->stateless()->user();
 
-        // Create or update the user
-        // $user = User::updateOrCreate(
-        //     ['email' => $googleUser->email],
-        //     [
-        //         'password' => Hash::make(Str::password(12)), // Use a random password
-        //         'social_id' => $googleUser->id, // Save Google ID for future reference
-        //         'is_verified' => true, // Assuming verified on successful social login
-        //         'signup_type' => 'Google',
-        //         'is_active' => true,
-        //     ]
-        // );
+        $user = User::updateOrCreate(
+            ['email' => $facebookUser->email],
+            [
+                'password' => Hash::make(Str::password(12)),
+                'social_id' => $facebookUser->id,
+                'is_verified' => true,
+                'signup_type' => 'Facebook',
+                'is_active' => true,
+            ]
+        );
 
-        // dd($user->profile);
-        // If profile is a separate model, ensure it is created or updated accordingly
-        // if ($user->profile) {
-        //     $user->profile->update([
-        //         'first_name' => $googleUser->user['given_name'],
-        //         'last_name' => $googleUser->user['family_name'],
-        //         'avatar_url' => $googleUser->attributes['avatar_original'],
-        //     ]);
-        // } else {
-        //     // Create a profile if it does not exist
-        //     $user->profile()->create([
-        //         'first_name' => $googleUser->user['given_name'],
-        //         'last_name' => $googleUser->user['family_name'],
-        //         'avatar_url' => $googleUser->attributes['avatar_original'],
-        //     ]);
-        // }
+        if ($user->profile) {
+            $user->profile->update([
+                'first_name' => $this->getFirstName($facebookUser->name),
+                'last_name' => $this->getLastName($facebookUser->name),
+                'avatar_url' => $facebookUser->avatar,
+            ]);
+        } else {
+            $user->profile()->create([
+                'first_name' => $this->getFirstName($facebookUser->name),
+                'last_name' => $this->getLastName($facebookUser->name),
+                'avatar_url' => $facebookUser->avatar,
+            ]);
+        }
 
-        // Generate JWT token
-        // $token = JWTAuth::fromUser($user);
+        $token = JWTAuth::fromUser($user);
 
-        // Prepare the response data
-        // $response = [
-        //     'status' => 'success',
-        //     'message' => 'User successfully authenticated',
-        //     'access_token' => $token,
-        //     'data' => [
-        //         'id' => $user->id,
-        //         'email' => $user->email,
-        //         'first_name' => $googleUser->user['given_name'],
-        //         'last_name' => $googleUser->user['family_name']
-        //     ]
-        // ];
+        $response = [
+            'status' => 'success',
+            'message' => 'User successfully authenticated',
+            'access_token' => $token,
+            'data' => [
+                'id' => $user->id,
+                'email' => $user->email,
+                'first_name' => $this->getFirstName($facebookUser->name),
+                'last_name' => $this->getLastName($facebookUser->name)
+            ]
+        ];
 
-        return response()->json($facebookUser);
+        return response()->json($response);
+    }
+
+    private function getFirstName($fullName)
+    {
+        $names = explode(' ', $fullName);
+        return count($names) > 2 ? $names[0] : $names[0];
+    }
+
+    private function getLastName($fullName)
+    {
+        $names = explode(' ', $fullName);
+        return count($names) > 2 ? end($names) : (count($names) > 1 ? $names[1] : '');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,7 +23,7 @@ class User extends Authenticatable  implements JWTSubject, CanResetPasswordContr
      *
      * @var array<int, string>
      */
-    protected $guarded  = ['id'];
+    protected $guarded  = [];
 
     /**
      * The attributes that should be hidden for serialization.
@@ -35,14 +35,14 @@ class User extends Authenticatable  implements JWTSubject, CanResetPasswordContr
         'remember_token',
     ];
 
-    protected $fillable = [
+    /* protected $fillable = [
         'name',
         'email',
         'password',
         'status',
         'deactivation_reason',
         'phone', 'is_active'
-    ];
+    ]; */
 
     /**
      * The attributes that should be cast.

--- a/routes/api.php
+++ b/routes/api.php
@@ -79,9 +79,7 @@ Route::prefix('v1')->group(function () {
     Route::get('/billing-plans', [BillingPlanController::class, 'index']);
     Route::get('/billing-plans/{id}', [BillingPlanController::class, 'getBillingPlan']);
 
-
     Route::middleware('throttle:10,1')->get('/topics/search', [ArticleController::class, 'search']);
-
 
     Route::middleware('auth:api')->group(function () {
         Route::get('/products', [ProductController::class, 'index']);
@@ -89,9 +87,6 @@ Route::prefix('v1')->group(function () {
         Route::delete('/products/{productId}', [ProductController::class, 'destroy']);
         Route::get('/products/{product_id}', [ProductController::class, 'show']);
     });
-
-
-
 
     //comment
     Route::middleware('auth:api')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -63,9 +63,11 @@ Route::prefix('v1')->group(function () {
     Route::get('/auth/google', [SocialAuthController::class, 'redirectToGoogle']);
     Route::get('/auth/login-google', [SocialAuthController::class, 'redirectToGoogle']);
     Route::get('/auth/google/callback', [SocialAuthController::class, 'handleGoogleCallback']);
+    Route::post('/auth/google/callback', [SocialAuthController::class, 'saveGoogleRequest']);
 
     Route::get('/auth/login-facebook', [SocialAuthController::class, 'loginUsingFacebook']);
     Route::get('/auth/facebook/callback', [SocialAuthController::class, 'callbackFromFacebook']);
+    Route::post('/auth/facebook/callback', [SocialAuthController::class, 'saveFacebookRequest']);
 
     Route::apiResource('/users', UserController::class);
 

--- a/tests/Unit/RegistrationTest.php
+++ b/tests/Unit/RegistrationTest.php
@@ -8,6 +8,7 @@ use Laravel\Socialite\Facades\Socialite;
 use App\Models\User;
 use App\Models\Profile;
 use Illuminate\Support\Str;
+use Illuminate\Http\Response;
 use Mockery;
 
 class RegistrationTest extends TestCase
@@ -121,9 +122,42 @@ class RegistrationTest extends TestCase
     }
 
     /** @test */
-    public function facebook_login_creates_or_updates_user_and_profile()
+    public function google_login_creates_or_updates_user_and_profile_with_post()
     {
         // Mock Google user response
+        $googleUser = [
+            'email' => 'john.doe@example.com',
+            'id' => 'google-id-12345',
+            'user' => [
+                'given_name' => 'John',
+                'family_name' => 'Doe',
+                'picture' => 'https://lh3.googleusercontent.com/a-/AOh14Gh2G_YHMAI' // Added picture URL
+            ],
+            'attributes' => [
+                'avatar_original' => 'https://lh3.googleusercontent.com/a-/AOh14Gh2G_YHMAI'
+            ]
+        ];
+
+        $response = $this->postJson('/api/v1/auth/google/callback', [
+            'google_user' => $googleUser
+        ]);
+
+        $response->assertStatus(Response::HTTP_OK);
+        
+        // Verify user in the database
+        $user = User::where('email', $googleUser['email'])->first();
+        $this->assertNotNull($user);
+        $this->assertEquals($googleUser['id'], $user->social_id);
+        $this->assertEquals('Google', $user->signup_type);
+        $this->assertEquals('John', $user->profile->first_name);
+        $this->assertEquals('Doe', $user->profile->last_name);
+        $this->assertEquals($googleUser['attributes']['avatar_original'], $user->profile->avatar_url);
+    }
+
+    /** @test */
+    public function facebook_login_creates_or_updates_user_and_profile()
+    {
+        // Mock Facebook user response
         $facebookUser = (object) [
             'id' => '10220927895907350',
             'nickname' => null,
@@ -150,12 +184,12 @@ class RegistrationTest extends TestCase
             'approvedScopes' => [""]
         ];
 
-        // Mock Socialite to return the mocked Google user
+        // Mock Socialite to return the mocked Facebook user
         Socialite::shouldReceive('driver->stateless->user')
             ->once()
             ->andReturn($facebookUser);
 
-        // Simulate the Google login
+        // Simulate the Facebook login
         $response = $this->get('/api/v1/auth/facebook/callback');
 
         // Check for success response
@@ -167,13 +201,58 @@ class RegistrationTest extends TestCase
 
         // Assert user creation or update
         $user = User::where('email', 'john.doe@example.com')->first();
-        // dd($user);
         $this->assertNotNull($user);
         $this->assertEquals('10220927895907350', $user->social_id);
 
-        $profile = $user->profile; // Ensure you have a profile relationship
+        $profile = $user->profile;
         $this->assertNotNull($profile);
         $this->assertEquals('John', $profile->first_name);
         $this->assertEquals('Doe', $profile->last_name);
+    }
+
+    /** @test */
+    public function facebook_login_creates_or_updates_user_and_profile_with_post()
+    {
+        // Mock Google user response
+        $facebookUser = [
+            'id' => '10220927895907350',
+            'nickname' => null,
+            'name' => 'John Doe',
+            'email' => 'john.doe@example.com',
+            'avatar' => 'https://graph.facebook.com/v3.3/10220927895907350/picture',
+            'user' => [
+                'name' => 'John Doe',
+                'email' => 'john.doe@example.com',
+                'id' => '102907350'
+            ],
+            'attributes' => [
+                'id' => '102209277350',
+                'nickname' => null,
+                'name' => 'John Doe',
+                'email' => 'john.doe@example.com',
+                'avatar' => 'https://graph.facebook.com/v3.3/102209907350/picture',
+                'avatar_original' => 'https://graph.facebook.com/v3.3/1022097350/picture?width=1920',
+                'profileUrl' => null
+            ],
+            'token' => 'EAAXSQSZAEan4BO48hdLYs84YGRXkTzBCZC5Pkpx3J6TlrmakX3SiMRJoYR2FYwb5hR1otRJxuGglfBVRJc9J9LgcDBOmHdsdblKZAFmPo6ZAwex6KN3DuRN9cyRM7ZCKGNdOWgvZCBmp0qUjhkaFUCr71L43ExxSc8ZAHQalcEDQqar9mXeg3EzuBasQFnFxOqFw3ZBbZBM3O91wENlK4YwZDZD',
+            'refreshToken' => null,
+            'expiresIn' => 5169882,
+            'approvedScopes' => [""]
+        ];
+
+        $response = $this->postJson('/api/v1/auth/facebook/callback', [
+            'facebook_user' => $facebookUser
+        ]);
+
+        $response->assertStatus(Response::HTTP_OK);
+        
+        // Verify user in the database
+        $user = User::where('email', $facebookUser['email'])->first();
+        $this->assertNotNull($user);
+        $this->assertEquals($facebookUser['id'], $user->social_id);
+        $this->assertEquals('Facebook', $user->signup_type);
+        $this->assertEquals('John', $user->profile->first_name);
+        $this->assertEquals('Doe', $user->profile->last_name);
+        $this->assertEquals($facebookUser['avatar'], $user->profile->avatar_url);
     }
 }


### PR DESCRIPTION
## Description
Facebook login can now save users data after bug detection
​
## Related Issue (Link to Github issue)

​
## Motivation and Context
This give user the ability to use facebook as mode of authentication into the app rather than relying on google auth only
​
## How Has This Been Tested?
All existing and new PHP Unit test are working
​
## Screenshots (if appropriate - Postman, etc):
​
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.