### PR TITLE
Feat: delete email template

### DIFF
--- a/app/Http/Controllers/Api/V1/Admin/EmailTemplateController.php
+++ b/app/Http/Controllers/Api/V1/Admin/EmailTemplateController.php
@@ -94,4 +94,28 @@ class EmailTemplateController extends Controller
             'data' => $template
         ], 200);
     }
+
+    public function destroy($id)
+{
+    // Find the email template by ID
+    $emailTemplate = EmailTemplate::find($id);
+
+    // Check if the email template exists
+    if (!$emailTemplate) {
+        return response()->json([
+            'status_code' => 404,
+            'error' => 'Not Found',
+            'message' => 'Email template not found'
+        ], 404);
+    }
+
+    // Delete the email template
+    $emailTemplate->delete();
+
+    // Return success response
+    return response()->json([
+        'status_code' => 200,
+        'message' => 'Email template deleted successfully'
+    ], 200);
+}
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -125,6 +125,7 @@ Route::prefix('v1')->group(function () {
     Route::middleware(['auth:api', 'admin'])->group(function () {
         Route::get('/email-templates', [EmailTemplateController::class, 'index']);
         Route::patch('/email-templates/{id}', [EmailTemplateController::class, 'update']);
+        Route::delete('/email-templates/{id}', [EmailTemplateController::class, 'destroy']);
     });
 
 

--- a/tests/Feature/EmailTemplateControllerTest.php
+++ b/tests/Feature/EmailTemplateControllerTest.php
@@ -229,4 +229,22 @@ class EmailTemplateControllerTest extends TestCase
         $response->assertStatus(404)
             ->assertJson(['error' => 'Template not found']);
     }
+    public function only_super_admin_can_delete_email_template()
+{
+    [$user, $token] = $this->getAuthenticatedUser('admin');
+
+    $emailTemplate = EmailTemplate::factory()->create();
+
+    $response = $this->withHeaders([
+        'Authorization' => 'Bearer ' . $token,
+        'Accept' => 'application/json',
+    ])->deleteJson('/api/v1/email-templates/' . $emailTemplate->id);
+
+    $response->assertStatus(200)
+             ->assertJson([
+                 'status_code' => 200,
+                 'message' => 'Email template deleted successfully'
+             ]);
+}
+
 }


### PR DESCRIPTION
This PR implements an API endpoint that deletes an email template
​
## Description
- [X] added API endpoint(DELETE /api/v1/email-templates/{id}) for deleting email templates.
- [x] only admin can delete template.
- [X] Handles unexpected errors and return the appropriate status code.
​
## Related Issue (Link to Github issue)
This PR is related to the issue [here](https://github.com/hngprojects/hng_boilerplate_php_laravel_web/issues/349)
​
## Motivation and Context
To allow admin delete email templates from database
​
## How Has This Been Tested?
Wrote Feature Test
  ✓ super admin can update email template  
​
## Screenshots
<img width="491" alt="Screenshot 2024-08-01 at 1 26 25 PM" src="https://github.com/user-attachments/assets/6e9b79cb-4e24-4e9f-9d2c-85964cd01c3a">


​
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

The documentation for this endpoint can be found [here](https://app.swaggerhub.com/apis/EZEANYIMHENRY/hng-boilerplate_by_team_jopak/1.0.0)