### PR TITLE
feat: added another forget password endpoint to allow otp rather than…

### DIFF
--- a/app/Http/Controllers/Api/V1/Auth/ForgetResetPasswordController.php
+++ b/app/Http/Controllers/Api/V1/Auth/ForgetResetPasswordController.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use App\Models\User;
+use Illuminate\Support\Facades\Validator;
+use App\Traits\HttpResponses;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rules\Password;
+use Illuminate\Support\Facades\Hash;
+
+class ForgetResetPasswordController extends Controller
+{
+    use HttpResponses;
+
+    /**
+     * Handle the incoming request.
+     */
+    public function forgetPassword(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'email' => 'required|email:rfc'
+        ]);
+
+        if ($validator->fails()) {
+            return $this->apiResponse(message:  $validator->errors(), status_code: 422);
+        }
+
+        $user = User::where('email', $request->email)->first();
+        if (!$user) {
+            return $this->apiResponse(message:  'User does not exist', status_code: 400);
+        }
+
+        // Create a new token
+        $randomNumber = Str::random(6);
+        $token = substr($randomNumber, 0, 6);
+
+        // Store the token in the password_reset_tokens table
+        DB::table('password_reset_tokens')->updateOrInsert(
+            ['email' => $request->email],
+            [
+                'token' => $token,
+                'created_at' => Carbon::now(),
+            ]
+        );
+        
+        $user->sendPasswordResetToken($token);
+
+        return $this->apiResponse(message:  'Password reset link sent');
+    }
+
+    /**
+     * Handle the incoming request.
+     */
+    public function resetPassword(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'email' => 'required|email:rfc',
+            'password' => ['required', 'string', Password::min(8)
+            ->letters()
+            ->mixedCase()
+            ->numbers()
+            ->symbols()
+            ->uncompromised()],
+        ]);
+
+        if ($validator->fails()) {
+            return $this->apiResponse(message: $validator->errors(), status_code: 400);
+        }
+
+        $user = User::where('email', $request->email)->first();
+        if (!$user) {
+            return $this->apiResponse(message: 'User does not exist', status_code: 400);
+        }
+
+        // Reset the password
+        $user->password = Hash::make($request->password);
+        $user->save();
+        
+        return $this->apiResponse(message: 'Password reset successfully', status_code: 200);
+    }
+
+    /**
+     * Handle the incoming request.
+     */
+    public function verifyUserOTP(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'email' => 'required|email:rfc',
+            'otp' => 'required|string|min:6|max:6',
+        ]);
+
+        if ($validator->fails()) {
+            return $this->apiResponse(message: $validator->errors(), status_code: 400);
+        }
+
+        // Check if the token exists in the password_reset_tokens table
+        $passwordReset = DB::table('password_reset_tokens')->where([
+            ['email', $request->email],
+            ['token', $request->otp],
+        ])->first();
+
+        // If the token is invalid, return an error
+        if (!$passwordReset) {
+            return $this->apiResponse(message: 'Invalid token', status_code: 400);
+        }
+
+        // Delete the password reset token after successful reset
+        DB::table('password_reset_tokens')->where([
+            ['email', $request->email],
+            ['token', $request->otp],
+        ])->delete();
+        
+        return $this->apiResponse(message: 'Token Validated Successfully', status_code: 200);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/ResetUserPasswordController.php
+++ b/app/Http/Controllers/Api/V1/Auth/ResetUserPasswordController.php
@@ -35,7 +35,7 @@ class ResetUserPasswordController extends Controller
         }
 
         // Check if the token exists in the password_reset_tokens table
-        $passwordReset = \DB::table('password_reset_tokens')->where([
+        $passwordReset = DB::table('password_reset_tokens')->where([
             ['email', $request->email],
             ['token', $token],
         ])->first();

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -204,4 +204,15 @@ class User extends Authenticatable  implements JWTSubject, CanResetPasswordContr
     {
         $this->notify(new \App\Notifications\ResetPasswordNotification($token));
     }
+
+     /**
+     * Send the password reset notification.
+     *
+     * @param  string  $token
+     * @return void
+     */
+    public function sendPasswordResetToken($token)
+    {
+        $this->notify(new \App\Notifications\ResetPasswordToken($token));
+    }
 }

--- a/app/Notifications/ResetPasswordToken.php
+++ b/app/Notifications/ResetPasswordToken.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ResetPasswordToken extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(public $token)
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Reset Password Token')
+            ->line('You are receiving this email because we received a password reset request for your account.')
+            ->line('Your reset OTP is:', $this->token)
+            ->line('If you did not request a password reset, no further action is required.');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\Api\V1\Auth\ForgetPasswordRequestController;
 use App\Http\Controllers\Api\V1\Auth\LoginController;
 use App\Http\Controllers\Api\V1\Auth\ResetUserPasswordController;
 use App\Http\Controllers\Api\V1\Auth\SocialAuthController;
+use App\Http\Controllers\Api\V1\Auth\ForgetResetPasswordController;
 use App\Http\Controllers\Api\V1\BlogSearchController;
 use App\Http\Controllers\Api\V1\CategoryController;
 use App\Http\Controllers\Api\V1\ContactController;
@@ -59,11 +60,16 @@ Route::prefix('v1')->group(function () {
     Route::post('/auth/logout', [LoginController::class, 'logout'])->middleware('auth:api');
     Route::post('/auth/password-reset-email', ForgetPasswordRequestController::class)->name('password.reset');
     Route::post('/auth/request-password-request/{token}', ResetUserPasswordController::class);
-    Route::post('/roles', [RoleController::class, 'store']);
     Route::get('/auth/google', [SocialAuthController::class, 'redirectToGoogle']);
     Route::get('/auth/login-google', [SocialAuthController::class, 'redirectToGoogle']);
     Route::get('/auth/google/callback', [SocialAuthController::class, 'handleGoogleCallback']);
     Route::post('/auth/google/callback', [SocialAuthController::class, 'saveGoogleRequest']);
+    /* Forget and Reset Password using OTP */
+    Route::post('/auth/forgot-password', [ForgetResetPasswordController::class, 'forgetPassword']);
+    Route::post('/auth/reset-forgot-password', [ForgetResetPasswordController::class, 'resetPassword']);
+    Route::post('/auth/verify-forget-otp', [ForgetResetPasswordController::class, 'verifyUserOTP']);
+
+    Route::post('/roles', [RoleController::class, 'store']);
 
     Route::get('/auth/login-facebook', [SocialAuthController::class, 'loginUsingFacebook']);
     Route::get('/auth/facebook/callback', [SocialAuthController::class, 'callbackFromFacebook']);

--- a/tests/Feature/ForgetPasswordRequestTest.php
+++ b/tests/Feature/ForgetPasswordRequestTest.php
@@ -10,7 +10,10 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use App\Models\User;
 use App\Notifications\ResetPasswordNotification;
+use App\Notifications\ResetPasswordToken;
 use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Str;
+use Carbon\Carbon;
 
 class ForgetPasswordRequestTest extends TestCase
 {
@@ -104,7 +107,90 @@ class ForgetPasswordRequestTest extends TestCase
     }
 
     /** @test */
-    /* public function can_send_password_reset_email()
+    public function it_fails_when_email_is_not_provided_via_token()
+    {
+        $response = $this->postJson('/api/v1/auth/forgot-password', []);
+        $response->assertStatus(422)
+                ->assertJson([
+                    'message' => [
+                        'email' => [
+                            'The email field is required.'
+                        ]
+                    ],
+                    'status_code' => 422
+                ]);
+    }
+
+     /** @test */
+     public function it_returns_error_when_user_does_not_exist_via_token()
+     {
+         // Create a valid email but without an associated user
+         $response = $this->postJson('/api/v1/auth/forgot-password', [
+             'email' => 'nonexistentuser@example.com',
+         ]);
+ 
+         $response->assertStatus(400)
+                 ->assertJson([
+                     'message' => 'User does not exist',
+                     'status_code' => 400
+                 ]);
+     }
+
+     /** @test */
+    public function it_returns_error_for_invalid_email_domain_via_token()
+    {
+        // Provide an email with a domain that should not be in the database
+        $response = $this->postJson('/api/v1/auth/forgot-password', [
+            'email' => 'test@invalid-domain.com',
+        ]);
+
+        $response->assertStatus(400)
+                ->assertJson([
+                    'message' => 'User does not exist',
+                    'status_code' => 400
+                ]);
+    }
+
+    /** @test */
+    public function it_returns_error_for_email_with_invalid_format_via_otp()
+    {
+        // Provide an invalid email format
+        $response = $this->postJson('/api/v1/auth/forgot-password', [
+            'email' => 'invalid-email-format',
+        ]);
+
+        $response->assertStatus(422)  // Expect validation error for invalid email format
+                ->assertJson([
+                    'message' => [
+                        'email' => [
+                            'The email field must be a valid email address.'
+                        ]
+                    ],
+                    'status_code' => 422
+                ]);
+    }
+
+    /** @test */
+    public function it_returns_error_when_email_field_is_empty_via_otp()
+    {
+        // Provide an empty email field
+        $response = $this->postJson('/api/v1/auth/forgot-password', [
+            'email' => '',
+        ]);
+
+        $response->assertStatus(422)  // Expect validation error for empty email
+                ->assertJson([
+                    'message' => [
+                        'email' => [
+                            'The email field is required.'
+                        ]
+                    ],
+                    'status_code' => 422
+                ]);
+    }
+
+    /** @test */
+    public function can_send_password_reset_email_via_otp()
     {
         Notification::fake();
 
@@ -112,37 +198,25 @@ class ForgetPasswordRequestTest extends TestCase
             'email' => 'test@example.com',
         ]);
 
-        $token = Password::createToken($user);
+        $randomNumber = Str::random(6);
+        $token = substr($randomNumber, 0, 6);
 
-        $response = $this->postJson('/api/v1/auth/password-reset-email', [
-            'email' => 'test@example.com',
+        // Store the token in the password_reset_tokens table
+        DB::table('password_reset_tokens')->updateOrInsert(
+            ['email' => $user->email],
+            [
+                'token' => $token,
+                'created_at' => Carbon::now(),
+            ]
+        );
+
+        $response = $this->postJson('/api/v1/auth/forgot-password', [
+            'email' => $user->email,
         ]);
 
         $response->assertStatus(200)
                  ->assertJson([
                      'message' => 'Password reset link sent',
                  ]);
-
-        // Assert a notification was sent
-        Notification::assertSentTo(
-            [$user],
-            ResetPasswordNotification::class,
-            function ($notification) use ($token, $user) {
-                // Extract the URL from the notification
-                $url = $notification->toMail($user)->actionUrl;
-
-                // Extract query parameters from the URL
-                $query = parse_url($url, PHP_URL_QUERY);
-                parse_str($query, $params);
-
-                // Verify  email in the URL
-                return $params['email'] === $user->email;
-            }
-        );
-
-        // Check if token is saved in the database
-        $this->assertDatabaseHas('password_reset_tokens', [
-            'email' => 'test@example.com',
-        ]);
-    } */
+    }
 }

--- a/tests/Feature/ResetUserPasswordTest.php
+++ b/tests/Feature/ResetUserPasswordTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
+use Illuminate\Support\Str;
 
 class ResetUserPasswordTest extends TestCase
 {
@@ -89,5 +90,47 @@ class ResetUserPasswordTest extends TestCase
             'password_confirmation' => 'Ed8M7s*)?e:hTb^#&;C!<ysdwe344'
         ])->assertStatus(400);
         //   ->assertJsonStructure(['message' => ['email', 'password']]);
+    }
+
+    /** @test */
+    public function it_resets_password_with_valid_after_otp()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->postJson("/api/v1/auth/reset-forgot-password", [
+            'email' => $user->email,
+            'password' => 'Ed8M7s*)?e:hTb^#&;C!<y',
+            'password_confirmation' => 'Ed8M7s*)?e:hTb^#&;C!<y'
+        ])
+        ->assertStatus(200)
+        ->assertJson(['message' => 'Password reset successfully']);
+
+        $this->assertTrue(Hash::check('Ed8M7s*)?e:hTb^#&;C!<y', $user->fresh()->password));
+    }
+
+    /** @test */
+    public function it_verify_user_otp_on_forget_password_request()
+    {
+        $user = User::factory()->create();
+
+        // Create a new token
+        $randomNumber = Str::random(6);
+        $token = substr($randomNumber, 0, 6);
+
+        // Store the token in the password_reset_tokens table
+        DB::table('password_reset_tokens')->updateOrInsert(
+            ['email' => $user->email],
+            [
+                'token' => $token,
+                'created_at' => Carbon::now(),
+            ]
+        );
+
+        $response = $this->postJson("/api/v1/auth/verify-forget-otp", [
+            'email' => $user->email,
+            'otp' => $token
+        ])
+        ->assertStatus(200)
+        ->assertJson(['message' => 'Token Validated Successfully']);
     }
 }

--- a/tests/Unit/ForgetPasswordRequestTest.php
+++ b/tests/Unit/ForgetPasswordRequestTest.php
@@ -6,6 +6,7 @@ use Tests\TestCase;
 use App\Models\User;
 use Illuminate\Support\Facades\Notification;
 use App\Notifications\ResetPasswordNotification;
+use App\Notifications\ResetPasswordToken;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -60,5 +61,25 @@ class ForgetPasswordRequestTest extends TestCase
         $this->assertStringContainsString($url, $mailMessage->actionUrl);
         $this->assertStringContainsString('Reset Password', $mailMessage->actionText);
         $this->assertStringContainsString('Reset Password Notification', $mailMessage->subject);
+    }
+
+    /** @test */
+    public function it_sends_password_reset_token_via_notification()
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+
+        $randomNumber = Str::random(6);
+        $token = substr($randomNumber, 0, 6);
+
+        $user->sendPasswordResetToken($token);
+
+        Notification::assertSentTo(
+            [$user], ResetPasswordToken::class,
+            function ($notification) use ($token) {
+                return $notification->token === $token;
+            }
+        );
     }
 }


### PR DESCRIPTION
## Description
Added another endpoint that allow forget password using OTP

## Related Issue (Link to Github issue)

​
## Motivation and Context
This gives room for users to use OTP rather than token
​
## How Has This Been Tested?
via PHPUnit
​
## Screenshots (if appropriate - Postman, etc):
​
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
