### PR TITLE
fix: added nullable column

### DIFF
--- a/database/migrations/2024_08_01_094152_modify_columns_on_blogs_table.php
+++ b/database/migrations/2024_08_01_094152_modify_columns_on_blogs_table.php
@@ -12,10 +12,10 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('blogs', function (Blueprint $table) {
-            $table->string('category');
-            $table->text('image_url');
+            $table->string('category')->nullable();
+            $table->text('image_url')->nullable();
             $table->dropColumn('blog_category_id');
-            $table->foreignUuid('author_id')->constrained('users', 'id')->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreignUuid('author_id')->nullable()->constrained('users', 'id')->cascadeOnDelete()->cascadeOnUpdate();
         });
         Schema::dropIfExists('blog_categories');
         Schema::dropIfExists('blog_images');

--- a/database/seeders/BlogSeeder.php
+++ b/database/seeders/BlogSeeder.php
@@ -6,6 +6,7 @@ use App\Models\Blog;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
@@ -16,6 +17,7 @@ class BlogSeeder extends Seeder
      */
     public function run(): void
     {
+        DB::table('blogs')->truncate();
         $categories = ['Business', 'Food', 'Lifestyle', 'World News'];
         $images = [
             'https://free-images.com/lg/dd2c/port_au_prince_haiti.jpg',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​Fixed nullable issue in other to migrate table without affecting existing data

## Description
Devops cant run php artisan:fresh so made some columns nullable in the new migration created , so php artisan migrate will run without affecting existing data
​
## Related Issue (Link to Github issue)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
​
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
​
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
​
## Screenshots (if appropriate - Postman, etc):
​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
