### PR TITLE
fix: sending empty top

### DIFF
--- a/app/Http/Controllers/Api/V1/Auth/ForgetResetPasswordController.php
+++ b/app/Http/Controllers/Api/V1/Auth/ForgetResetPasswordController.php
@@ -36,8 +36,7 @@ class ForgetResetPasswordController extends Controller
         }
 
         // Create a new token
-        $randomNumber = Str::random(6);
-        $token = substr($randomNumber, 0, 6);
+        $token = random_int(100000, 999999);
 
         // Store the token in the password_reset_tokens table
         DB::table('password_reset_tokens')->updateOrInsert(
@@ -91,7 +90,7 @@ class ForgetResetPasswordController extends Controller
     {
         $validator = Validator::make($request->all(), [
             'email' => 'required|email:rfc',
-            'otp' => 'required|string|min:6|max:6',
+            'otp' => ['required', 'digits:6', 'integer'],
         ]);
 
         if ($validator->fails()) {

--- a/app/Notifications/ResetPasswordToken.php
+++ b/app/Notifications/ResetPasswordToken.php
@@ -37,7 +37,7 @@ class ResetPasswordToken extends Notification implements ShouldQueue
         return (new MailMessage)
             ->subject('Reset Password Token')
             ->line('You are receiving this email because we received a password reset request for your account.')
-            ->line('Your reset OTP is:', $this->token)
+            ->line('Your reset OTP is: '. $this->token)
             ->line('If you did not request a password reset, no further action is required.');
     }
 

--- a/tests/Feature/ForgetPasswordRequestTest.php
+++ b/tests/Feature/ForgetPasswordRequestTest.php
@@ -198,8 +198,7 @@ class ForgetPasswordRequestTest extends TestCase
             'email' => 'test@example.com',
         ]);
 
-        $randomNumber = Str::random(6);
-        $token = substr($randomNumber, 0, 6);
+        $token = random_int(100000, 999999);
 
         // Store the token in the password_reset_tokens table
         DB::table('password_reset_tokens')->updateOrInsert(

--- a/tests/Feature/ResetUserPasswordTest.php
+++ b/tests/Feature/ResetUserPasswordTest.php
@@ -114,8 +114,7 @@ class ResetUserPasswordTest extends TestCase
         $user = User::factory()->create();
 
         // Create a new token
-        $randomNumber = Str::random(6);
-        $token = substr($randomNumber, 0, 6);
+        $token = random_int(100000, 999999);
 
         // Store the token in the password_reset_tokens table
         DB::table('password_reset_tokens')->updateOrInsert(


### PR DESCRIPTION
## Description
Fix error on getting otp for forgot password
​
## Related Issue (Link to Github issue)

​
## Motivation and Context
It currently return empty otp, so it has been fixed up
​
## How Has This Been Tested?
PHP Unit
​
## Screenshots (if appropriate - Postman, etc):
​
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.