### PR TITLE
feat: notification settings view and update documentation

### DIFF
--- a/custom_endpoints.yaml
+++ b/custom_endpoints.yaml
@@ -324,3 +324,97 @@ components:
           type: string
           format: string
           example: 'xeoo'
+
+  /api/v1/notification-settings:
+    get:
+      summary: Get notification settings
+      tags:
+        - NotificationSettings
+      responses:
+        '200':
+          description: Notification preferences retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  message:
+                    type: string
+                  status_code:
+                    type: integer
+                  data:
+                    type: object
+                    properties:
+                      email_notification_activity_in_workspace:
+                        type: boolean
+                      email_notification_always_send_email_notifications:
+                        type: boolean
+                      email_notification_email_digest:
+                        type: boolean
+                      email_notification_announcement_and_update_emails:
+                        type: boolean
+                      slack_notifications_activity_on_your_workspace:
+                        type: boolean
+                      slack_notifications_always_send_email_notifications:
+                        type: boolean
+                      slack_notifications_announcement_and_update_emails:
+                        type: boolean
+
+    patch:
+      summary: Update notification settings
+      tags:
+        - NotificationSettings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email_notification_activity_in_workspace:
+                  type: boolean
+                email_notification_always_send_email_notifications:
+                  type: boolean
+                email_notification_email_digest:
+                  type: boolean
+                email_notification_announcement_and_update_emails:
+                  type: boolean
+                slack_notifications_activity_on_your_workspace:
+                  type: boolean
+                slack_notifications_always_send_email_notifications:
+                  type: boolean
+                slack_notifications_announcement_and_update_emails:
+                  type: boolean
+      responses:
+        '200':
+          description: Notification preferences updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  message:
+                    type: string
+                  status_code:
+                    type: integer
+                  data:
+                    type: object
+                    properties:
+                      email_notification_activity_in_workspace:
+                        type: boolean
+                      email_notification_always_send_email_notifications:
+                        type: boolean
+                      email_notification_email_digest:
+                        type: boolean
+                      email_notification_announcement_and_update_emails:
+                        type: boolean
+                      slack_notifications_activity_on_your_workspace:
+                        type: boolean
+                      slack_notifications_always_send_email_notifications:
+                        type: boolean
+                      slack_notifications_announcement_and_update_emails:
+                        type: boolean


### PR DESCRIPTION
# Notification Settings API
## Retrieve Notification Settings

Retrieves the current notification settings for the authenticated user.

 -   URL: /notifications/settings
 -   Method: GET
 -   Response: JSON object containing the user's notification settings

## Update Notification Settings

Updates the notification settings for the authenticated user.

-    URL: /notifications/settings
-    Method: PATCH
-    Request Body: JSON object containing the updated notification settings
-    Response: JSON object containing the updated notification settings

## Example Use Cases

 -   Retrieve the current notification settings:

``` bash

curl -X GET \

  http://example.com/notifications/settings \

  -H 'Authorization: Bearer YOUR_API_TOKEN'
```

 -   Update the notification settings:

``` bash

curl -X PATCH \

  http://example.com/notifications/settings \

  -H 'Authorization: Bearer YOUR_API_TOKEN' \

  -H 'Content-Type: application/json' \

  -d '{"notifications": {"email": true, "push": false}}'
```

### API Response

``` json

{

  "notifications": {

    "email": true,

    "push": false

  }

}
```

Error Handling

 -   401 Unauthorized: Authentication failed
 -   422 Unprocessable Entity: Invalid request body
