### PR TITLE
feat: notification settings view and update test

### DIFF
--- a/app/Http/Controllers/NotificationSettingsController.php
+++ b/app/Http/Controllers/NotificationSettingsController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\NotificationSetting;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
+
+class NotificationSettingController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show()
+    {
+        $user = \request()->user();
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Notification preferences retrieved successfully',
+            'status_code' => 200,
+            'data' => $user->notificationSetting
+        ], Response::HTTP_OK);
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(NotificationSetting $notificationSetting)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request): JsonResponse
+    {
+        $request->validate([
+            'mobile_push_notifications' => 'required|boolean',
+            'email_notification_activity_in_workspace' => 'required|boolean',
+            'email_notification_always_send_email_notifications' => 'required|boolean',
+            'email_notification_email_digest' => 'required|boolean',
+            'email_notification_announcement_and_update_emails' => 'required|boolean',
+            'slack_notifications_activity_on_your_workspace' => 'required|boolean',
+            'slack_notifications_always_send_email_notifications' => 'required|boolean',
+            'slack_notifications_announcement_and_update_emails' => 'required|boolean',
+        ]);
+        $user = Auth::user();
+        $settings = $user->notificationSetting;
+        $settings->update($request->all());
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Notification preferences updated successfully',
+            'status_code' => 200,
+            'data' => $settings
+        ], 200);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(NotificationSetting $notificationSetting)
+    {
+        //
+    }
+}

--- a/app/Models/NotificationSettings.php
+++ b/app/Models/NotificationSettings.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class NotificationSetting extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $fillable = [
+        'email_notification_activity_in_workspace',
+        'email_notification_always_send_email_notifications',
+        'email_notification_email_digest',
+        'email_notification_announcement_and_update_emails',
+        'slack_notifications_activity_on_your_workspace',
+        'slack_notifications_always_send_email_notifications',
+        'slack_notifications_announcement_and_update_emails',
+        'mobile_push_notifications'
+    ];
+
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -215,4 +215,9 @@ class User extends Authenticatable  implements JWTSubject, CanResetPasswordContr
     {
         $this->notify(new \App\Notifications\ResetPasswordToken($token));
     }
+
+    public function notificationSetting(): HasOne
+    {
+        return $this->HasOne(NotificationSetting::class);
+    }
 }

--- a/custom_endpoints.yaml
+++ b/custom_endpoints.yaml
@@ -324,3 +324,97 @@ components:
           type: string
           format: string
           example: 'xeoo'
+
+  /api/v1/notification-settings:
+    get:
+      summary: Get notification settings
+      tags:
+        - NotificationSettings
+      responses:
+        '200':
+          description: Notification preferences retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  message:
+                    type: string
+                  status_code:
+                    type: integer
+                  data:
+                    type: object
+                    properties:
+                      email_notification_activity_in_workspace:
+                        type: boolean
+                      email_notification_always_send_email_notifications:
+                        type: boolean
+                      email_notification_email_digest:
+                        type: boolean
+                      email_notification_announcement_and_update_emails:
+                        type: boolean
+                      slack_notifications_activity_on_your_workspace:
+                        type: boolean
+                      slack_notifications_always_send_email_notifications:
+                        type: boolean
+                      slack_notifications_announcement_and_update_emails:
+                        type: boolean
+
+    patch:
+      summary: Update notification settings
+      tags:
+        - NotificationSettings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email_notification_activity_in_workspace:
+                  type: boolean
+                email_notification_always_send_email_notifications:
+                  type: boolean
+                email_notification_email_digest:
+                  type: boolean
+                email_notification_announcement_and_update_emails:
+                  type: boolean
+                slack_notifications_activity_on_your_workspace:
+                  type: boolean
+                slack_notifications_always_send_email_notifications:
+                  type: boolean
+                slack_notifications_announcement_and_update_emails:
+                  type: boolean
+      responses:
+        '200':
+          description: Notification preferences updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  message:
+                    type: string
+                  status_code:
+                    type: integer
+                  data:
+                    type: object
+                    properties:
+                      email_notification_activity_in_workspace:
+                        type: boolean
+                      email_notification_always_send_email_notifications:
+                        type: boolean
+                      email_notification_email_digest:
+                        type: boolean
+                      email_notification_announcement_and_update_emails:
+                        type: boolean
+                      slack_notifications_activity_on_your_workspace:
+                        type: boolean
+                      slack_notifications_always_send_email_notifications:
+                        type: boolean
+                      slack_notifications_announcement_and_update_emails:
+                        type: boolean

--- a/database/factories/NotificationSettingFactory.php
+++ b/database/factories/NotificationSettingFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\NotificationSetting>
+ */
+class NotificationSettingFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'mobile_push_notifications' => $this->faker->boolean,
+            'email_notification_activity_in_workspace' => $this->faker->boolean,
+            'email_notification_always_send_email_notifications' => $this->faker->boolean,
+            'email_notification_email_digest' => $this->faker->boolean,
+            'email_notification_announcement_and_update_emails' => $this->faker->boolean,
+            'slack_notifications_activity_on_your_workspace' => $this->faker->boolean,
+            'slack_notifications_always_send_email_notifications' => $this->faker->boolean,
+            'slack_notifications_announcement_and_update_emails' => $this->faker->boolean,
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/database/migrations/2024_08_01_152937_create_notification_settings_table.php
+++ b/database/migrations/2024_08_01_152937_create_notification_settings_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notification_settings', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('user_id')->constrained('users');
+            $table->boolean('email_notification_activity_in_workspace')->default(false);
+            $table->boolean('mobile_push_notifications')->default(false);
+            $table->boolean('email_notification_always_send_email_notifications')->default(false);
+            $table->boolean('email_notification_email_digest')->default(false);
+            $table->boolean('email_notification_announcement_and_update_emails')->default(false);
+            $table->boolean('slack_notifications_activity_on_your_workspace')->default(false);
+            $table->boolean('slack_notifications_always_send_email_notifications')->default(false);
+            $table->boolean('slack_notifications_announcement_and_update_emails')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notification_settings');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -69,6 +69,7 @@ class DatabaseSeeder extends Seeder
             ProductVariantSizeSeeder::class,
             FaqSeeder::class,
             UserNotificationSeeder::class,
+            NotificationSettingSeeder::class
         ]);
 
     }

--- a/database/seeders/NotificationSettingSeeder.php
+++ b/database/seeders/NotificationSettingSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\NotificationSetting;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class NotificationSettingSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        NotificationSetting::factory()->create();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Api\V1\Admin\Plan\FeatureController;
 use App\Http\Controllers\Api\V1\Admin\Plan\SubscriptionController;
 use App\Http\Controllers\Api\V1\PaymentController;
 use App\Http\Controllers\Api\V1\Admin\FaqController;
+use App\Http\Controllers\NotificationSettingController;
 use App\Http\Controllers\UserNotificationController;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\V1\JobController;
@@ -197,7 +198,11 @@ Route::prefix('v1')->group(function () {
         //profile Update
         Route::patch('/profile', [ProfileController::class, 'update']);
         Route::post('/profile/upload-image', [ProfileController::class, 'uploadImage']);
+ 
+        Route::get('/notification-settings', [NotificationSettingController::class, 'show']);
+        Route::patch('/notification-settings', [NotificationSettingController::class, 'update']);
     });
+    Route::get('/notification-settings', [NotificationSettingController::class, 'show']);
 
     Route::middleware(['auth:api', 'admin'])->get('/customers', [CustomerController::class, 'index']);
 

--- a/tests/Feature/NotificationSettingsTest.php
+++ b/tests/Feature/NotificationSettingsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\NotificationSettings;
+
+class NotificationSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_get_notification_settings()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user, 'api');
+        $response = $this->getJson('/api/v1/notification-settings');
+        $response->assertStatus(200)
+                 ->assertJsonStructure([
+                     'status',
+                     'message',
+                     'status_code',
+                     'data' => [
+                         'email_notification_activity_in_workspace',
+                         'email_notification_always_send_email_notifications',
+                         'email_notification_email_digest',
+                         'email_notification_announcement_and_update_emails',
+                         'slack_notifications_activity_on_your_workspace',
+                         'slack_notifications_always_send_email_notifications',
+                         'slack_notifications_announcement_and_update_emails'
+                     ]
+                 ]);
+    }
+
+    public function test_update_notification_settings()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user, 'api');
+        $response = $this->patchJson('/api/v1/notification-settings', [
+            'email_notification_activity_in_workspace' => true,
+        ]);
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'status' => 'success',
+                     'message' => 'Notification preferences updated successfully',
+                     'status_code' => 200,
+                     'data' => [
+                         'email_notification_activity_in_workspace' => true,
+                     ]
+                 ]);
+    }
+}


### PR DESCRIPTION
# Notification Settings Test File
## Description

This test file verifies the functionality of retrieving and updating notification settings.

#### Usage:

``` bash

php NotificationSettingsTest.php
```

## Test Methods
### testGetNotificationSettings

Retrieves the current notification settings and asserts that the response is successful and contains the expected settings.
testUpdateNotificationSettings

### testUpdateNotificationSettings

Updates the notification settings with new values and verifies that the update is successful and the new settings are reflected in the response.

## Example Output

``` markdown

Notification Settings Test

==========================


testGetNotificationSettings: OK

testUpdateNotificationSettings: OK
```