### PR TITLE
feat: notification settings view and update test

### DIFF
--- a/tests/Feature/NotificationSettingsTest.php
+++ b/tests/Feature/NotificationSettingsTest.php
@@ -14,9 +14,12 @@ class NotificationSettingsTest extends TestCase
     public function test_get_notification_settings()
     {
         $user = User::factory()->create();
-//        $notificationSettings = NotificationSettings::factory()->create(['user_id' => $user->id]);
+        $notificationSettings = NotificationSettings::factory()->create(['user_id' => $user->id]); // Uncomment this line
+
         $this->actingAs($user, 'api');
+
         $response = $this->getJson('/api/v1/notification-settings');
+
         $response->assertStatus(200)
                  ->assertJsonStructure([
                      'status',
@@ -37,8 +40,10 @@ class NotificationSettingsTest extends TestCase
     public function test_update_notification_settings()
     {
         $user = User::factory()->create();
- //       $notificationSettings = NotificationSettings::factory()->create(['user_id' => $user->id]);
+        $notificationSettings = NotificationSettings::factory()->create(['user_id' => $user->id]); // Uncomment this line
+
         $this->actingAs($user, 'api');
+
         $response = $this->patchJson('/api/v1/notification-settings', [
             'email_notification_activity_in_workspace' => true,
             'email_notification_always_send_email_notifications' => true,
@@ -47,7 +52,9 @@ class NotificationSettingsTest extends TestCase
             'slack_notifications_activity_on_your_workspace' => true,
             'slack_notifications_always_send_email_notifications' => true,
             'slack_notifications_announcement_and_update_emails' => true,
+            'mobile_push_notifications' => true // Add this field
         ]);
+
         $response->assertStatus(200)
                  ->assertJson([
                      'status' => 'success',
@@ -60,7 +67,7 @@ class NotificationSettingsTest extends TestCase
                          'email_notification_announcement_and_update_emails' => true,
                          'slack_notifications_activity_on_your_workspace' => true,
                          'slack_notifications_always_send_email_notifications' => true,
-                         'slack_notifications_announcement_and_update_emails' => true,
+                         'slack_notifications_announcement_and_update_emails' => true
                      ]
                  ]);
     }

--- a/tests/Feature/NotificationSettingsTest.php
+++ b/tests/Feature/NotificationSettingsTest.php
@@ -14,7 +14,7 @@ class NotificationSettingsTest extends TestCase
     public function test_get_notification_settings()
     {
         $user = User::factory()->create();
-        $notificationSettings = NotificationSettings::factory()->create(['user_id' => $user->id]);
+//        $notificationSettings = NotificationSettings::factory()->create(['user_id' => $user->id]);
         $this->actingAs($user, 'api');
         $response = $this->getJson('/api/v1/notification-settings');
         $response->assertStatus(200)
@@ -37,7 +37,7 @@ class NotificationSettingsTest extends TestCase
     public function test_update_notification_settings()
     {
         $user = User::factory()->create();
-        $notificationSettings = NotificationSettings::factory()->create(['user_id' => $user->id]);
+ //       $notificationSettings = NotificationSettings::factory()->create(['user_id' => $user->id]);
         $this->actingAs($user, 'api');
         $response = $this->patchJson('/api/v1/notification-settings', [
             'email_notification_activity_in_workspace' => true,

--- a/tests/Feature/NotificationSettingsTest.php
+++ b/tests/Feature/NotificationSettingsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\NotificationSettings;
+
+class NotificationSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_get_notification_settings()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user, 'api');
+        $response = $this->getJson('/api/v1/notification-settings');
+        $response->assertStatus(200)
+                 ->assertJsonStructure([
+                     'status',
+                     'message',
+                     'status_code',
+                     'data' => [
+                         'email_notification_activity_in_workspace',
+                         'email_notification_always_send_email_notifications',
+                         'email_notification_email_digest',
+                         'email_notification_announcement_and_update_emails',
+                         'slack_notifications_activity_on_your_workspace',
+                         'slack_notifications_always_send_email_notifications',
+                         'slack_notifications_announcement_and_update_emails'
+                     ]
+                 ]);
+    }
+
+    public function test_update_notification_settings()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user, 'api');
+        $response = $this->patchJson('/api/v1/notification-settings', [
+            'email_notification_activity_in_workspace' => true,
+        ]);
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'status' => 'success',
+                     'message' => 'Notification preferences updated successfully',
+                     'status_code' => 200,
+                     'data' => [
+                         'email_notification_activity_in_workspace' => true,
+                     ]
+                 ]);
+    }
+}

--- a/tests/Feature/NotificationSettingsTest.php
+++ b/tests/Feature/NotificationSettingsTest.php
@@ -14,6 +14,7 @@ class NotificationSettingsTest extends TestCase
     public function test_get_notification_settings()
     {
         $user = User::factory()->create();
+        $notificationSettings = NotificationSettings::factory()->create(['user_id' => $user->id]);
         $this->actingAs($user, 'api');
         $response = $this->getJson('/api/v1/notification-settings');
         $response->assertStatus(200)
@@ -36,9 +37,16 @@ class NotificationSettingsTest extends TestCase
     public function test_update_notification_settings()
     {
         $user = User::factory()->create();
+        $notificationSettings = NotificationSettings::factory()->create(['user_id' => $user->id]);
         $this->actingAs($user, 'api');
         $response = $this->patchJson('/api/v1/notification-settings', [
             'email_notification_activity_in_workspace' => true,
+            'email_notification_always_send_email_notifications' => true,
+            'email_notification_email_digest' => true,
+            'email_notification_announcement_and_update_emails' => true,
+            'slack_notifications_activity_on_your_workspace' => true,
+            'slack_notifications_always_send_email_notifications' => true,
+            'slack_notifications_announcement_and_update_emails' => true,
         ]);
         $response->assertStatus(200)
                  ->assertJson([
@@ -47,6 +55,12 @@ class NotificationSettingsTest extends TestCase
                      'status_code' => 200,
                      'data' => [
                          'email_notification_activity_in_workspace' => true,
+                         'email_notification_always_send_email_notifications' => true,
+                         'email_notification_email_digest' => true,
+                         'email_notification_announcement_and_update_emails' => true,
+                         'slack_notifications_activity_on_your_workspace' => true,
+                         'slack_notifications_always_send_email_notifications' => true,
+                         'slack_notifications_announcement_and_update_emails' => true,
                      ]
                  ]);
     }


### PR DESCRIPTION
# Notification Settings Test File
## Description

This test file verifies the functionality of retrieving and updating notification settings.

### Usage:

``` bash

php NotificationSettingsTest.php
```

## Test Methods
### testGetNotificationSettings

Retrieves the current notification settings and asserts that the response is successful and contains the expected settings.

### testUpdateNotificationSettings

Updates the notification settings with new values and verifies that the update is successful and the new settings are reflected in the response.

## Example Output

``` markdown

Notification Settings Test

==========================


testGetNotificationSettings: OK

testUpdateNotificationSettings: OK
```