### PR TITLE
fix: product image upload

### DIFF
--- a/app/Http/Controllers/Api/V1/ProductController.php
+++ b/app/Http/Controllers/Api/V1/ProductController.php
@@ -193,15 +193,18 @@ class ProductController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(CreateProductRequest $request)
-    {
-
-        $org_id = $request->route('org_id');
-
+    public function store(CreateProductRequest $request, $org_id)
+    {        
         $isOwner = OrganisationUser::where('org_id', $org_id)->where('user_id', auth()->id())->exists();
 
         if (!$isOwner) {
             return response()->json(['message' => 'You are not authorized to create products for this organization.'], 403);
+        }
+
+        $imageUrl = null;
+        if($request->hasFile('image')) {
+            $imagePath = $request->file('image')->store('product_images', 'public');
+            $imageUrl = Storage::url($imagePath);
         }
 
         $product = Product::create([
@@ -210,8 +213,7 @@ class ProductController extends Controller
             'slug' => Carbon::now(),
             'tags' => $request->input('category'),
             'price' => $request->input('price'),
-            // 'imageUrl' => $imageUrl,
-            'imageUrl' => $request->input('image'),
+            'imageUrl' => $imageUrl,
             'user_id' => auth()->id(),
             'org_id' => $org_id
         ]);

--- a/app/Http/Requests/CreateProductRequest.php
+++ b/app/Http/Requests/CreateProductRequest.php
@@ -27,7 +27,7 @@ class CreateProductRequest extends FormRequest
             'category' => 'required|uuid|exists:categories,id',
             'price' => 'required|numeric',
             'stock' => 'required|integer',
-            // 'image' => 'required|image|mimes:jpeg,png,jpg,gif|max:2048',
+            'image' => 'required|image|mimes:jpeg,png,jpg,gif|max:1024',
         ];
     }
 }

--- a/tests/Feature/ProductCreateTest.php
+++ b/tests/Feature/ProductCreateTest.php
@@ -10,7 +10,8 @@ use App\Models\ProductVariant;
 use App\Models\Size;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
 class ProductCreateTest extends TestCase
@@ -19,89 +20,89 @@ class ProductCreateTest extends TestCase
 
     /** @test */
     public function it_can_create_a_product()
-{
-    // Create a user and authenticate
-    $user = User::factory()->create();
-    $this->actingAs($user);
+    {
+        // Create a user and authenticate
+        $user = User::factory()->create();
+        $this->actingAs($user);
 
-    // Create a size with 'standard'
-    $size = Size::create(['size' => 'standard']);
+        // Create a size with 'standard'
+        $size = Size::create(['size' => 'standard']);
 
-    // Create a category
-    $category = Category::create(['name' => 'Test Category', 'slug' => 'test-category', 'description' => 'Testing']);
+        // Create a category
+        $category = Category::create(['name' => 'Test Category', 'slug' => 'test-category', 'description' => 'Testing']);
 
-    // Create an organisation and get the first instance
-    $organisation = Organisation::factory()->create();
+        // Create an organisation and get the first instance
+        $organisation = Organisation::factory()->create();
 
-    // Associate the user with the organization as an owner
-    OrganisationUser::create([
-        'org_id' => $organisation->org_id,
-        'user_id' => $user->id,
-        // 'role' => 'owner' // Ensure this is the correct role for authorization
-    ]);
+        // Associate the user with the organization as an owner
+        OrganisationUser::create([
+            'org_id' => $organisation->org_id,
+            'user_id' => $user->id,
+        ]);
 
-    // Define the payload
-    $payload = [
-        'title' => 'Test Product',
-        'description' => 'Test Description',
-        'category' => $category->id, // Use the created category ID
-        'price' => 100,
-        'stock' => 10,
-        'image' => 'test_image.jpg',
-        'org_id' => $organisation->org_id
-    ];
+        // Define the payload with an image file
+        Storage::fake('public');
+        $image = UploadedFile::fake()->image('test_image.jpg');
 
-    // Send POST request to create product
-    $response = $this->postJson("/api/v1/organizations/{$organisation->org_id}/products", $payload);
+        $payload = [
+            'title' => 'Test Product',
+            'description' => 'Test Description',
+            'category' => $category->id, // Use the created category ID
+            'price' => 100,
+            'stock' => 10,
+            'image' => $image,
+        ];
 
-    // Assert the response status and structure
-    $response->assertStatus(201)
-             ->assertJsonStructure([
-                 'message',
-                 'product' => [
-                     'name',
-                     'description',
-                     'slug',
-                     'tags',
-                     'price',
-                     'imageUrl',
-                     'user_id',
-                     'updated_at',
-                     'created_at',
-                 ]
-             ]);
+        // Send POST request to create product
+        $response = $this->postJson("/api/v1/organizations/{$organisation->org_id}/products", $payload);
 
-    // Assert the product is created in the database
-    $this->assertDatabaseHas('products', [
-        'name' => 'Test Product',
-        'description' => 'Test Description',
-        'tags' => $category->id,
-        'price' => 100,
-        'imageUrl' => 'test_image.jpg',
-        'user_id' => $user->id
-    ]);
+        // Assert the response status and structure
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'message',
+                'product' => [
+                    'name',
+                    'description',
+                    'slug',
+                    'tags',
+                    'price',
+                    'imageUrl',
+                    'user_id',
+                    'updated_at',
+                    'created_at',
+                ]
+            ]);
 
-    // Assert the category_product relationship is created
-    $this->assertDatabaseHas('category_product', [
-        'category_id' => $category->id,
-        'product_id' => Product::first()->product_id
-    ]);
+        // Assert the product is created in the database
+        $this->assertDatabaseHas('products', [
+            'name' => 'Test Product',
+            'description' => 'Test Description',
+            'tags' => $category->id,
+            'price' => 100,
+            'user_id' => $user->id
+        ]);
 
-    // Assert the product variant is created with the correct size
-    $this->assertDatabaseHas('product_variants', [
-        'product_id' => Product::first()->product_id,
-        'stock' => 10,
-        'stock_status' => 'in_stock',
-        'price' => 100,
-        'size_id' => $size->id
-    ]);
+        // Assert the category_product relationship is created
+        $this->assertDatabaseHas('category_product', [
+            'category_id' => $category->id,
+            'product_id' => Product::first()->product_id
+        ]);
 
-    // Assert the product variant size is created
-    $this->assertDatabaseHas('product_variant_sizes', [
-        'product_variant_id' => ProductVariant::first()->id,
-        'size_id' => $size->id
-    ]);
-}
+        // Assert the product variant is created with the correct size
+        $this->assertDatabaseHas('product_variants', [
+            'product_id' => Product::first()->product_id,
+            'stock' => 10,
+            'stock_status' => 'in_stock',
+            'price' => 100,
+            'size_id' => $size->id
+        ]);
+
+        // Assert the product variant size is created
+        $this->assertDatabaseHas('product_variant_sizes', [
+            'product_variant_id' => ProductVariant::first()->id,
+            'size_id' => $size->id
+        ]);
+    }
 
     /** @test */
     public function it_cannot_create_a_product_if_not_an_owner()
@@ -120,15 +121,17 @@ class ProductCreateTest extends TestCase
         // Create an organisation and get the first instance
         $organisation = Organisation::factory()->create();
 
-        // Define the payload
+        // Define the payload with an image file
+        Storage::fake('public');
+        $image = UploadedFile::fake()->image('test_image.jpg');
+
         $payload = [
             'title' => 'Unauthorized Product',
             'description' => 'Unauthorized Description',
             'category' => $category->id, // Use the created category ID
             'price' => 100,
             'stock' => 10,
-            'image' => 'test_image.jpg',
-            'org_id' => $organisation->org_id
+            'image' => $image,
         ];
 
         // Send POST request to create product
@@ -136,6 +139,6 @@ class ProductCreateTest extends TestCase
 
         // Assert the response status is 403 Forbidden
         $response->assertStatus(403)
-                 ->assertJson(['message' => 'You are not authorized to create products for this organization.']);
+            ->assertJson(['message' => 'You are not authorized to create products for this organization.']);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​
## Description
<!--- Describe your changes in detail -->
This is a fix to the current implementation which treats the image url being sent with the payload instead of an actual image upload
​
## Related Issue (Link to Github issue)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/hngprojects/hng_boilerplate_nestjs/issues/87
​
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
​
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Adjusted the previous test to handle the file upload too
​
## Screenshots (if appropriate - Postman, etc):
![Screenshot 2024-08-06 161542](https://github.com/user-attachments/assets/afb7d7c1-06db-4544-8bea-4faa83827a25)

​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
