### PR TITLE
feat: create squeeze page by admin

### DIFF
--- a/app/Http/Controllers/Api/V1/SqueezePageCoontroller.php
+++ b/app/Http/Controllers/Api/V1/SqueezePageCoontroller.php
@@ -43,9 +43,9 @@ class SqueezePageCoontroller extends Controller
     public function store(CreateSqueezePageRequest $request)
     {
         try {
-            $validated = $request->validate();
+            $validated = $request->validated();
 
-            $squeeze_page = SqueezePage::create([$validated]);
+            $squeeze_page = SqueezePage::create($validated);
 
             return response()->json([
                 'status_code' => Response::HTTP_OK,

--- a/app/Http/Controllers/Api/V1/SqueezePageCoontroller.php
+++ b/app/Http/Controllers/Api/V1/SqueezePageCoontroller.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\CreateSqueezePageRequest;
 use App\Models\SqueezePage;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -15,12 +16,12 @@ class SqueezePageCoontroller extends Controller
     public function index()
     {
         try {
-            $plans = SqueezePage::select(['id', 'title', 'slug', 'created_at', 'status', 'activate'])->get();
+            $squezee_pages = SqueezePage::select(['id', 'title', 'slug', 'created_at', 'status', 'activate'])->get();
             return response()->json([
                 'status' => Response::HTTP_OK,
                 'message' => 'Squeeze Pages retrieved successfully',
-                'data' => $plans,
-            ]);
+                'data' => $squezee_pages,
+            ], Response::HTTP_OK);
         } catch (\Exception $e) {
             return response()->json([
                 'message' => 'Internal server error',
@@ -34,15 +35,34 @@ class SqueezePageCoontroller extends Controller
      */
     public function create()
     {
-        //
     }
 
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(CreateSqueezePageRequest $request)
     {
-        //
+        try {
+            $validated = $request->validate();
+            $squeeze_page = SqueezePage::create($validated);
+            return response()->json([
+                'status_code' => Response::HTTP_OK,
+                'message' => 'Squeeze page created successfully',
+                'data' => [
+                    'id' => $squeeze_page->id,
+                    'title' => $squeeze_page->title,
+                    'slug' => $squeeze_page->slug,
+                    'created_at' => $squeeze_page->created_at,
+                    'status' => $squeeze_page->status,
+                    'activate' => $squeeze_page->activate
+                ]
+            ], Response::HTTP_OK);
+        } catch (\Exception $e) {
+            return response()->json([
+                'message' => 'Internal server error',
+                'status' => Response::HTTP_INTERNAL_SERVER_ERROR
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
     }
 
     /**

--- a/app/Http/Controllers/Api/V1/SqueezePageCoontroller.php
+++ b/app/Http/Controllers/Api/V1/SqueezePageCoontroller.php
@@ -44,7 +44,9 @@ class SqueezePageCoontroller extends Controller
     {
         try {
             $validated = $request->validate();
-            $squeeze_page = SqueezePage::create($validated);
+
+            $squeeze_page = SqueezePage::create([$validated]);
+
             return response()->json([
                 'status_code' => Response::HTTP_OK,
                 'message' => 'Squeeze page created successfully',
@@ -57,6 +59,7 @@ class SqueezePageCoontroller extends Controller
                     'activate' => $squeeze_page->activate
                 ]
             ], Response::HTTP_OK);
+
         } catch (\Exception $e) {
             return response()->json([
                 'message' => 'Internal server error',

--- a/app/Http/Controllers/Api/V1/SqueezePageCoontroller.php
+++ b/app/Http/Controllers/Api/V1/SqueezePageCoontroller.php
@@ -48,7 +48,7 @@ class SqueezePageCoontroller extends Controller
             $squeeze_page = SqueezePage::create($validated);
 
             return response()->json([
-                'status_code' => Response::HTTP_OK,
+                'status_code' => Response::HTTP_CREATED,
                 'message' => 'Squeeze page created successfully',
                 'data' => [
                     'id' => $squeeze_page->id,
@@ -58,7 +58,7 @@ class SqueezePageCoontroller extends Controller
                     'status' => $squeeze_page->status,
                     'activate' => $squeeze_page->activate
                 ]
-            ], Response::HTTP_OK);
+            ], Response::HTTP_CREATED);
 
         } catch (\Exception $e) {
             return response()->json([

--- a/app/Http/Requests/CreateSqueezePageRequest.php
+++ b/app/Http/Requests/CreateSqueezePageRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Response;
+
+
+class CreateSqueezePageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|string|max:255',
+            'slug' => 'nullable|string|max:255|unique:squeeze_pages,slug',
+            'status' => 'required|in:offline,online',
+            'activate' => 'required|boolean',
+            'headline' => 'required|string|max:255',
+            'sub_headline' => 'required|string|max:255',
+            'hero_image' => 'required|string|max:255',
+            'content' => 'required|string',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator)
+    {
+        $errors = (new ValidationException($validator))->errors();
+
+        $formattedError = [];
+
+        foreach ($errors as $field => $messages) {
+            foreach ($messages as $message) {
+                $formattedError[] = [
+                    "field" => $field,
+                    "message" => $message
+                ];
+            }
+        }
+
+        throw new HttpResponseException(response()->json([
+            'status_code' => Response::HTTP_BAD_REQUEST,
+            'errors' => $formattedError,
+        ], Response::HTTP_BAD_REQUEST));
+    }
+}

--- a/tests/Feature/SqueezePagesTest.php
+++ b/tests/Feature/SqueezePagesTest.php
@@ -52,4 +52,59 @@ class SqueezePagesTest extends TestCase
         $response = $this->getJson('/api/v1/squeeze-pages');
         $response->assertStatus(401);
     }
+
+
+
+    public function test_if_admin_can_create_squeeze_page()
+    {
+        $payload = [
+            'title' => 'Email Mastery',
+            'slug' => 'email-mastery',
+            'status' => 'online',
+            'activate' => true,
+            'headline' => 'Master the Art of Email Marketing',
+            'sub_headline' => 'Unlock the Secrets to Email Campaign Success',
+            'hero_image' => 'email_marketing_hero.jpg',
+            'content' => 'This is a comprehensive guide to mastering email marketing...',
+        ];
+
+        $response = $this->withHeaders(['Authorization' => "Bearer $this->adminToken"])
+            ->postJson('/api/v1/squeeze-pages', $payload);
+
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'status_code',
+                'message',
+                'data' => ['id', 'title', 'slug', 'created_at', 'status', 'activate']
+            ]);
+
+        $this->assertDatabaseHas('faqs', $payload);
+    }
+
+    public function test_if_create_squeeze_page_missing_field_fails()
+    {
+        $payload = [
+            'slug' => 'email-mastery',
+            'status' => 'online',
+            'activate' => true,
+            'headline' => 'Master the Art of Email Marketing',
+            'sub_headline' => 'Unlock the Secrets to Email Campaign Success',
+            'hero_image' => 'email_marketing_hero.jpg',
+            'content' => 'This is a comprehensive guide to mastering email marketing...',
+        ];
+
+        $response = $this->withHeaders(['Authorization' => "Bearer $this->adminToken"])
+            ->postJson('/api/v1/squeeze-pages', $payload);
+
+        $response->assertStatus(400)
+            ->assertJsonStructure([
+                'status_code',
+                'errors' => [
+                    '*' => [
+                        'field',
+                        'message'
+                    ],
+                ]
+            ]);
+    }
 }

--- a/tests/Feature/SqueezePagesTest.php
+++ b/tests/Feature/SqueezePagesTest.php
@@ -78,7 +78,7 @@ class SqueezePagesTest extends TestCase
                 'data' => ['id', 'title', 'slug', 'created_at', 'status', 'activate']
             ]);
 
-        $this->assertDatabaseHas('faqs', $payload);
+        $this->assertDatabaseHas('squeeze_pages', $payload);
     }
 
     public function test_if_create_squeeze_page_missing_field_fails()

--- a/tests/Unit/RegistrationTest.php
+++ b/tests/Unit/RegistrationTest.php
@@ -6,11 +6,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use Laravel\Socialite\Facades\Socialite;
 use App\Models\User;
-use App\Models\Profile;
-use Illuminate\Support\Str;
 use Illuminate\Http\Response;
-use Mockery;
-use Illuminate\Support\Facades\DB;
 
 class RegistrationTest extends TestCase
 {
@@ -186,7 +182,7 @@ class RegistrationTest extends TestCase
                 'avatar_original' => 'https://graph.facebook.com/v3.3/1022097350/picture?width=1920',
                 'profileUrl' => null
             ],
-            'token' => 'EAAXSQSZAEan4BO48hdLYs84YGRXkTzBCZC5Pkpx3J6TlrmakX3SiMRJoYR2FYwb5hR1otRJxuGglfBVRJc9J9LgcDBOmHdsdblKZAFmPo6ZAwex6KN3DuRN9cyRM7ZCKGNdOWgvZCBmp0qUjhkaFUCr71L43ExxSc8ZAHQalcEDQqar9mXeg3EzuBasQFnFxOqFw3ZBbZBM3O91wENlK4YwZDZD',
+            'token' => env('TOKEN_AUTH'),
             'refreshToken' => null,
             'expiresIn' => 5169882,
             'approvedScopes' => [""]
@@ -242,7 +238,7 @@ class RegistrationTest extends TestCase
                 'avatar_original' => 'https://graph.facebook.com/v3.3/1022097350/picture?width=1920',
                 'profileUrl' => null
             ],
-            'token' => 'EAAXSQSZAEan4BO48hdLYs84YGRXkTzBCZC5Pkpx3J6TlrmakX3SiMRJoYR2FYwb5hR1otRJxuGglfBVRJc9J9LgcDBOmHdsdblKZAFmPo6ZAwex6KN3DuRN9cyRM7ZCKGNdOWgvZCBmp0qUjhkaFUCr71L43ExxSc8ZAHQalcEDQqar9mXeg3EzuBasQFnFxOqFw3ZBbZBM3O91wENlK4YwZDZD',
+            'token' => env('TOKEN_AUTH'),
             'refreshToken' => null,
             'expiresIn' => 5169882,
             'approvedScopes' => [""]


### PR DESCRIPTION
## Description
This pull request implements new API endpoints to enable authenticated and authorised user with admin role create a squeeze pages. This endpoint uses the post method.
​
## Related Issue (Link to Github issue)
Feature []()
​
Endpoints
POST /api/v1/squeeze-pages

Body

```
{
    "title": "Updated Squeeze Page",
    "status": "inactive",
    "activate": false,
    "headline": "Updated Headline",
    "sub_headline": "Updated Sub Headline",
    "hero_image": "updated_image.jpg",
    "content": "Updated content"
}

```

Response

```
{
    "status_code": 201,
    "message": "Squeeze page retrieved successfully",
    "data": {
        "id": 1,
        "title": "Updated Squeeze Page",
        "slug": "updated-squeeze-page",
        "created_at": "2024-08-05T14:35:22.000000Z",
        "status": "offline",
        "activate": false
    }
}

```

Enable creation squeeze pages by admin

## How Has This Been Tested?
- Successful response with squeeze page details
- Does not return response for unauthorized user
- Appropriate status code


## Screenshots (if appropriate - Postman, etc):
![image](https://github.com/user-attachments/assets/47c47528-a167-4c8b-b2d9-9ee31316edb2)

​
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
