### PR TITLE
feat: Super Admin Edit (Update) FAQ's

### DIFF
--- a/app/Http/Controllers/Api/V1/Admin/FaqController.php
+++ b/app/Http/Controllers/Api/V1/Admin/FaqController.php
@@ -77,5 +77,71 @@ class FaqController extends Controller
             ], 500);
         }
     }
+
+    public function update(Request $request, $id)
+    {
+        try {
+            $validatedData = $request->validate([
+                'question' => 'required|string|max:255',
+                'answer' => 'required|string',
+                'category' => 'required|string',
+            ]);
+    
+            $faq = Faq::findOrFail($id);
+    
+            $faq->update([
+                'question' => $validatedData['question'],
+                'answer' => $validatedData['answer'],
+                'category' => $validatedData['category'],
+            ]);
+    
+            return response()->json([
+                'status_code' => 200,
+                'message' => 'FAQ updated successfully',
+                'data' => [
+                    'question' => $faq->question,
+                    'answer' => $faq->answer,
+                    'category' => $faq->category,
+                    'id' => $faq->id,
+                    'created_at' => $faq->created_at->toIso8601String(),
+                    'updated_at' => $faq->updated_at->toIso8601String(),
+                ]
+            ], 200);
+    
+        } catch (ValidationException $e) {
+            return response()->json([
+                'status_code' => 422,
+                'message' => 'Validation failed',
+                'data' => $e->errors()
+            ], 422);
+    
+        } catch (Exception $e) {
+            return response()->json([
+                'status_code' => 500,
+                'message' => 'An error occurred while updating the FAQ',
+                'data' => []
+            ], 500);
+        }
+    }
+
+    public function destroy($id)
+    {
+        try {
+            $faq = Faq::findOrFail($id);
+            $faq->delete();
+    
+            return response()->json([
+                'status_code' => 200,
+                'message' => 'FAQ successfully deleted'
+            ], 200);
+    
+        } catch (Exception $e) {
+            return response()->json([
+                'status_code' => 500,
+                'message' => 'An error occurred while deleting the FAQ',
+                'data' => []
+            ], 500);
+        }
+    }
     
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -258,8 +258,6 @@ Route::prefix('v1')->group(function () {
         Route::get('/squeeze-pages/filter', [SqueezePageCoontroller::class, 'filter']);
         Route::apiResource('squeeze-pages', SqueezePageCoontroller::class);
         Route::get('/dashboard/statistics', [AdminDashboardController::class, 'getStatistics']);
-        Route::put('/faqs/{faq}', [FaqController::class, 'update']);
-        Route::delete('/faqs/{faq}', [FaqController::class, 'destroy']);
         Route::get('/dashboard/top-products', [AdminDashboardController::class, 'getTopProducts']);
         Route::get('/dashboard/all-top-products', [AdminDashboardController::class, 'getAllProductsSortedBySales']);
     });
@@ -324,6 +322,8 @@ Route::prefix('v1/admin')->group(function () {
 
     Route::group(['middleware' => ['auth.jwt', 'superadmin']], function () {
         Route::post('/faqs', [FaqController::class, 'store']);
+        Route::put('/faqs/{id}', [FaqController::class, 'update']);
+        Route::delete('/faqs/{id}', [FaqController::class, 'destroy']);
     });
 
     Route::get('/faqs', [FaqController::class, 'index']);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​
## Description
Endpoint that allows Users with Super Admin Roles to Edit FAQ's
​
## Related Issue (Link to Github issue)
[linear issue ](https://linear.app/language-learning-ai-game/issue/BULBE-68/[be]-[boilerplate]-[internal-pages]-super-admin-edit-update-faqs)
​
## Motivation and Context
The route of the endpoint should be:
PUT: /api/v1/faqs/:id (Super Admin Route) Update FAQ
​
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
​tested with postman and unit test

## Screenshots (if appropriate - Postman, etc):
![Screenshot (147)](https://github.com/user-attachments/assets/2cd8fc93-4527-47ad-b96b-fab7d69a096f)
![Screenshot (148)](https://github.com/user-attachments/assets/40879ba5-60ba-43e8-80b9-d8a2e80d06f7)
![Screenshot (149)](https://github.com/user-attachments/assets/d7cde625-6785-460a-83a2-f757307c13e5)
![Screenshot (150)](https://github.com/user-attachments/assets/693a02e9-fc19-4380-a213-0ca971b88467)

​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
