### PR TITLE
Feat:Super Admin Delete FAQ's

### DIFF
--- a/app/Http/Controllers/Api/V1/Admin/FaqController.php
+++ b/app/Http/Controllers/Api/V1/Admin/FaqController.php
@@ -125,7 +125,7 @@ class FaqController extends Controller
         }
     }
 
-    public function destroy($id)
+public function destroy($id)
     {
         try {
             $faq = Faq::findOrFail($id);

--- a/routes/api.php
+++ b/routes/api.php
@@ -328,8 +328,8 @@ Route::prefix('v1/admin')->group(function () {
 
     Route::group(['middleware' => ['auth.jwt', 'superadmin']], function () {
         Route::post('/faqs', [FaqController::class, 'store']);
-        Route::put('/faqs/{id}', [FaqController::class, 'update']);
-        Route::delete('/faqs/{id}', [FaqController::class, 'destroy']);
+            Route::put('/faqs/{id}', [FaqController::class, 'update']);
+            Route::delete('/faqs/{id}', [FaqController::class, 'destroy']);
     });
         Route::get('/faqs', [FaqController::class, 'index']);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​
## Description
<!--- Describe your changes in detail -->
​Endpoint that allows Users with Super Admin Roles to Delete FAQ's

## Related Issue (Link to Github issue)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
​[linear issue](https://linear.app/faq-super-admin-feature/issue/FAQ-12/[be]-super-admin-delete-faqs)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
e of the endpoint should be:
DELETE: /api/v1/faqs/:id  (Super Admin Route)
Response Body
```
{
    "status_code": 200,
    "message": "FAQ successfully deleted"
}
```
​
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
​
## Screenshots (if appropriate - Postman, etc):
​
![Screenshot (149)](https://github.com/user-attachments/assets/391284c4-3065-421a-aa76-10173cbf4bb8)
![Screenshot (151)](https://github.com/user-attachments/assets/712f8de6-203e-4326-90ee-e83d03a7a038)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
