### PR TITLE
feat: email processing

### DIFF
--- a/app/Http/Controllers/Api/V1/Admin/EmailTemplateController.php
+++ b/app/Http/Controllers/Api/V1/Admin/EmailTemplateController.php
@@ -100,7 +100,7 @@ class EmailTemplateController extends Controller
 
         // Validate request data
         $validatedData = $request->validate([
-            'title' => 'required|string|max:255',
+            'title' => 'required|string|max:255|unique:email_templates,title',
             'template' => 'required|string',
             'status' => 'required|boolean'
         ]);

--- a/app/Http/Controllers/Api/V1/Auth/AuthController.php
+++ b/app/Http/Controllers/Api/V1/Auth/AuthController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\V1\Auth;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreUserRequest;
 use App\Http\Resources\UserResource;
+use App\Models\EmailTemplate;
 use Illuminate\Http\Request;
 use App\Traits\HttpResponses;
 use Illuminate\Http\Response;
@@ -90,9 +91,17 @@ class AuthController extends Controller
 
             DB::commit();
 
+            $email_template_id = null;
+
+            $emailTemplate = EmailTemplate::where('title', 'welcome-email')->first();;
+            if ($emailTemplate) {
+                $email_template_id = $emailTemplate->id;
+            }
+
             return response()->json([
                 'status_code' => 201,       
                 "message" => "User Created Successfully",
+                'email_template_id' => $email_template_id,
                 'access_token' => $token,
                 'data' => [
                     'user' => new UserResource($user->load('owned_organisations', 'profile'))

--- a/app/Models/EmailTemplate.php
+++ b/app/Models/EmailTemplate.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 class EmailTemplate extends Model
 {
@@ -15,6 +16,15 @@ class EmailTemplate extends Model
         'template',
         'status',
     ];
+
+    protected static function boot()
+{
+    parent::boot();
+
+    static::saving(function ($model) {
+        $model->title = Str::slug($model->title);
+    });
+}
 
     public function emailRequests()
     {

--- a/tests/Feature/EmailTemplateControllerTest.php
+++ b/tests/Feature/EmailTemplateControllerTest.php
@@ -173,7 +173,7 @@ class EmailTemplateControllerTest extends TestCase
                 'message' => 'Email template updated successfully',
                 'data' => [
                     'id' => $template->id,
-                    'title' => 'Updated Template Title',
+                    'title' => 'updated-template-title',
                     'template' => 'Updated Template Content',
                     'status' => true,
                 ],
@@ -181,7 +181,7 @@ class EmailTemplateControllerTest extends TestCase
 
         $this->assertDatabaseHas('email_templates', [
             'id' => $template->id,
-            'title' => 'Updated Template Title',
+            'title' => 'updated-template-title',
             'template' => 'Updated Template Content',
             'status' => true,
         ]);


### PR DESCRIPTION

## Description
This PR implements email templating and returns template id for registered user response
​
## Related Issue (Link to Github issue)
Related Issue [here](https://github.com/hngprojects/hng_boilerplate_php_laravel_web/issues/221)
​
## Motivation and Context
Allows for sending of email without interfering with the app process
​
## How Has This Been Tested?
Tested using Postman
​
## Screenshots (if appropriate - Postman, etc):
<img width="672" alt="Screenshot 2024-08-15 at 10 03 11 PM" src="https://github.com/user-attachments/assets/6ac79314-9735-4c19-b285-e38c525988a7">

​
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
