### PR TITLE
fix: refactoring blog creation endpoint to meet C# standard

### DIFF
--- a/app/Http/Controllers/Api/V1/Admin/BlogController.php
+++ b/app/Http/Controllers/Api/V1/Admin/BlogController.php
@@ -93,17 +93,17 @@ class BlogController extends Controller
      */
     public function store(Request $request)
     {
-        $author = User::where('id', Auth::id())->first();
-        if(!$author){
-            return response()->json(['error' => 'User Not found.'], 404);
+        $author = User::find(Auth::id());
+
+        if (!$author) {
+            return response()->json(['error' => 'User not found.'], 404);
         }
 
-        Log::error('Error creating blog post: ' . Auth::id());
         $validator = Validator::make($request->all(), [
-            'title' => ['required', 'string', 'max:255'],
-            'content' => ['required', 'string'],
-            'image_url' => ['required', 'mimes:jpeg,png,jpg,gif,svg'],
-            'category' => ['required', 'string', 'max:255'],
+            'title' => 'required|string|max:255',
+            'content' => 'required|string',
+            'category' => 'required|string|max:255',
+            'image_url' => 'required|mimes:jpeg,png,jpg,gif,svg',
         ]);
 
         if ($validator->fails()) {
@@ -112,27 +112,47 @@ class BlogController extends Controller
                 'status_code' => 422,
             ], 422);
         }
+
         try {
             DB::beginTransaction();
-            $saved = Storage::disk('public')->put('images', $request->file('image_url'));
+
+            $savedPath = Storage::disk('public')->put('images', $request->file('image_url'));
+            $imageUrl = url('storage/' . $savedPath);
+
             $blog = Blog::create([
                 'title' => $request->get('title'),
-                'content' => (string)$request->get('content'),
-                'author' => $author->name ? $author->name : "",
-                'image_url' => 'storage/'.$saved,
+                'content' => $request->get('content'),
+                'author' => $author->name ?? '',
+                'image_url' => $imageUrl,
                 'category' => $request->get('category'),
-                'author_id' => $author->id
+                'author_id' => $author->id,
             ]);
 
             DB::commit();
+
             return response()->json([
-                'data' => $blog,
-                'message' => 'Blog post created successfully.',
-                'status_code' => Response::HTTP_CREATED,
+                'id' => $blog->id,
+                'title' => $blog->title,
+                'image_url' => $blog->image_url,
+                'content' => $blog->content,
+                'published_date' => $blog->created_at->toIso8601String(),
+                'updated_date' => $blog->updated_at->toIso8601String(),
+                'author_id' => $blog->author_id,
+                'category' => $blog->category,
+                'comments' => $blog->comments->map(function ($comment) {
+                    return [
+                        'id' => $comment->id,
+                        'content' => $comment->content,
+                        'created_at' => $comment->created_at->toIso8601String(),
+                    ];
+                }),
             ], Response::HTTP_CREATED);
+            
+
         } catch (\Exception $exception) {
             Log::error('Error creating blog post: ' . $exception->getMessage());
             DB::rollBack();
+
             return response()->json(['error' => 'Internal server error.'], 500);
         }
     }

--- a/app/Models/Blog.php
+++ b/app/Models/Blog.php
@@ -29,4 +29,9 @@ class Blog extends Model
      * @var string
      */
     protected $keyType = 'string';
+
+    public function comments(): HasMany
+    {
+        return $this->hasMany(Comment::class);
+    }
 }

--- a/tests/Feature/BlogControllerTest.php
+++ b/tests/Feature/BlogControllerTest.php
@@ -171,6 +171,7 @@ class BlogControllerTest extends TestCase
             ->deleteJson("/api/v1/blogs/{$blog->id}")
             ->assertStatus(401); // Forbidden
     }
+
     public function test_blog_creation_endpoint_is_protected()
     {
         $response = $this->postJson('/api/v1/blogs', [
@@ -193,22 +194,33 @@ class BlogControllerTest extends TestCase
         $response = $this->withHeaders(['Authorization' => "Bearer $token"])->postJson('/api/v1/blogs', [
             'title' => 'Test Blog Post',
             'content' => 'This is a test blog post content.',
-            'author' => $admin->name,
             'author_id' => $admin->id,
             'image_url' => $image,
             'category' => 'Example 2',
         ]);
 
         $response->assertStatus(201)
+            ->assertJsonStructure([
+                'id',
+                'title',
+                'image_url',
+                'content',
+                'published_date',
+                'updated_date',
+                'author_id',
+                'category',
+                'comments'
+            ])
             ->assertJson([
-                'message' => 'Blog post created successfully.',
-                'status_code' => 201,
+                'title' => 'Test Blog Post',
+                'content' => 'This is a test blog post content.',
+                'author_id' => $admin->id,
+                'category' => 'Example 2',
             ]);
 
         $this->assertDatabaseHas('blogs', [
             'title' => 'Test Blog Post',
             'content' => 'This is a test blog post content.',
-            'author' => $admin->name,
             'author_id' => $admin->id,
             'image_url' => $imageUrl,
             'category' => 'Example 2',


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Enhanced the API endpoint to handle the creation of new blog posts to match with the SSOT (C#)
​
## Related Issue (Link to Github issue)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/hngprojects/hng_boilerplate_nestjs/issues/865
​
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change was necessary so as to align it to C# method and allow for seamless integration.
​
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has been tested on postman and also passed unit tests
​
## Screenshots (if appropriate - Postman, etc):
![image](https://github.com/user-attachments/assets/1d422e6b-a74c-4a48-b574-b49f3e01cd3c)
![image](https://github.com/user-attachments/assets/a66e6b09-3043-4e63-9734-714664f98051)
​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
