### PR TITLE
FIX:Refactoring API Endpoint for "Retrieves a Specific Help Center Topic by ID"

### DIFF
--- a/app/Http/Controllers/Api/V1/HelpArticleController.php
+++ b/app/Http/Controllers/Api/V1/HelpArticleController.php
@@ -313,16 +313,16 @@ class HelpArticleController extends Controller
         }
     }
 
-    public function show($id)
+    public function show($articleId)
     {
         try {
-            $article = HelpArticle::findOrFail($id);
+            $article = HelpArticle::findOrFail($articleId);
             
             $author = User::find($article->user_id);
-            $authorName = $author ? $author->first_name . ' ' . $author->last_name : null;
+            $authorName = $author ? $author->name : null;
     
             $data = [
-                'id' => $article->id,
+                'id' => $article->article_id,
                 'title' => $article->title,
                 'content' => $article->content,
                 'author' => $authorName

--- a/app/Http/Controllers/Api/V1/HelpArticleController.php
+++ b/app/Http/Controllers/Api/V1/HelpArticleController.php
@@ -312,4 +312,35 @@ class HelpArticleController extends Controller
             ], 500);
         }
     }
+
+    public function show($id)
+    {
+        try {
+            $article = HelpArticle::findOrFail($id);
+            
+            $author = User::find($article->user_id);
+            $authorName = $author ? $author->first_name . ' ' . $author->last_name : null;
+    
+            $data = [
+                'id' => $article->id,
+                'title' => $article->title,
+                'content' => $article->content,
+                'author' => $authorName
+            ];
+    
+            return response()->json([
+                'status_code' => 200,
+                'message' => 'Request completed successfully',
+                'data' => $data
+            ], 200);
+        } catch (\Exception $e) {
+            return response()->json([
+                'status_code' => 404,
+                'message' => 'Help article not found',
+                'data' => null
+            ], 404);
+        }
+    }
+    
+    
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -164,6 +164,7 @@ Route::prefix('v1')->group(function () {
 
     // Help Articles
     Route::post('/help-center/topics', [HelpArticleController::class, 'store']);
+    Route::get('/v1/help-center/topics/{id}', [HelpArticleController::class, 'show']);
     Route::patch('/help-center/topics/{articleId}', [HelpArticleController::class, 'update']);
     Route::delete('/help-center/topics/{articleId}', [HelpArticleController::class, 'destroy']);
     Route::get('/help-center/topics', [HelpArticleController::class, 'getArticles']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -164,7 +164,7 @@ Route::prefix('v1')->group(function () {
 
     // Help Articles
     Route::post('/help-center/topics', [HelpArticleController::class, 'store']);
-    Route::get('/v1/help-center/topics/{id}', [HelpArticleController::class, 'show']);
+    Route::get('/help-center/topics/{articleId}', [HelpArticleController::class, 'show']);
     Route::patch('/help-center/topics/{articleId}', [HelpArticleController::class, 'update']);
     Route::delete('/help-center/topics/{articleId}', [HelpArticleController::class, 'destroy']);
     Route::get('/help-center/topics', [HelpArticleController::class, 'getArticles']);


### PR DESCRIPTION
## Description
Endpoint for retrieving a Specific Help Center Topic by ID.

## related issue
https://github.com/hngprojects/hng_boilerplate_nestjs/issues/1042
https://github.com/hngprojects/hng_boilerplate_php_laravel_web/issues/560

## Route
`GET: /api/v1/help-center/topics/{id}
`
### Response Body
```
{
  "status_code": 0,
  "message": "string",
  "data": {
    "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
    "title": "string",
    "content": "string",
    "author": "string"
  }
}
```
![Screenshot (197)](https://github.com/user-attachments/assets/50c1319a-3cf9-4b84-8c6e-417f35c39051)
