### PR TITLE
FIX: Refactoring API Endpoint for "Updates an Existing Help Center Topic"

### DIFF
--- a/app/Http/Controllers/Api/V1/HelpArticleController.php
+++ b/app/Http/Controllers/Api/V1/HelpArticleController.php
@@ -313,16 +313,16 @@ class HelpArticleController extends Controller
         }
     }
 
-    public function show($id)
+    public function show($articleId)
     {
         try {
-            $article = HelpArticle::findOrFail($id);
+            $article = HelpArticle::findOrFail($articleId);
             
             $author = User::find($article->user_id);
-            $authorName = $author ? $author->first_name . ' ' . $author->last_name : null;
+            $authorName = $author ? $author->name : null;
     
             $data = [
-                'id' => $article->id,
+                'id' => $article->article_id,
                 'title' => $article->title,
                 'content' => $article->content,
                 'author' => $authorName

--- a/app/Http/Controllers/Api/V1/HelpArticleController.php
+++ b/app/Http/Controllers/Api/V1/HelpArticleController.php
@@ -312,4 +312,35 @@ class HelpArticleController extends Controller
             ], 500);
         }
     }
+
+    public function show($id)
+    {
+        try {
+            $article = HelpArticle::findOrFail($id);
+            
+            $author = User::find($article->user_id);
+            $authorName = $author ? $author->first_name . ' ' . $author->last_name : null;
+    
+            $data = [
+                'id' => $article->id,
+                'title' => $article->title,
+                'content' => $article->content,
+                'author' => $authorName
+            ];
+    
+            return response()->json([
+                'status_code' => 200,
+                'message' => 'Request completed successfully',
+                'data' => $data
+            ], 200);
+        } catch (\Exception $e) {
+            return response()->json([
+                'status_code' => 404,
+                'message' => 'Help article not found',
+                'data' => null
+            ], 404);
+        }
+    }
+    
+    
 }

--- a/app/Http/Controllers/Api/V1/HelpArticleController.php
+++ b/app/Http/Controllers/Api/V1/HelpArticleController.php
@@ -81,74 +81,47 @@ class HelpArticleController extends Controller
 
     public function update(Request $request, $articleId)
     {
-        // Ensure the user is authenticated
-        if (!Auth::check()) {
-            return response()->json([
-                'status_code' => 401,
-                'success' => false,
-                'message' => 'Authentication failed'
-            ], 401);
-        }
-
-        // Validate the input
-        $validator = Validator::make($request->all(), [
-            'title' => 'nullable|string|max:255',
-            'content' => 'nullable|string',
-        ]);
-
-        if ($validator->fails()) {
-            return response()->json([
-                'status_code' => 400,
-                'success' => false,
-                'message' => 'Invalid input data.',
-                'errors' => $validator->errors()
-            ], 400);
-        }
-
         try {
-            $article = HelpArticle::find($articleId);
-
-            if (!$article) {
+            $article = HelpArticle::findOrFail($articleId);
+    
+            $validator = Validator::make($request->all(), [
+                'title' => 'nullable|string|max:255',
+                'content' => 'nullable|string',
+            ]);
+    
+            if ($validator->fails()) {
                 return response()->json([
-                    'status_code' => 404,
+                    'status_code' => 400,
                     'success' => false,
-                    'message' => 'Help article not found.'
-                ], 404);
+                    'message' => 'Invalid input data.',
+                    'errors' => $validator->errors()
+                ], 400);
             }
-
-            // Check if the authenticated user is the author of the article
-            if (Auth::id() !== $article->user_id) {
-                return response()->json([
-                    'status_code' => 403,
-                    'success' => false,
-                    'message' => 'You do not have permission to update this article.'
-                ], 403);
-            }
-
+    
             $article->update($request->only(['title', 'content']));
-
+            $data = [
+                'id' => $article->article_id,
+                'title' => $article->title,
+                'content' => $article->content,
+                'author' =>$article->user_id 
+            ];
+    
             return response()->json([
                 'status_code' => 200,
-                'success' => true,
-                'message' => 'Help article updated successfully.',
-                'data' => $article
-            ]);
-        } catch (QueryException $e) {
-            return response()->json([
-                'status_code' => 500,
-                'success' => false,
-                'message' => 'Failed to update help article. Please try again later.',
-                'error' => $e->getMessage() // Include error message
-            ], 500);
+                'message' => 'Topic updated successfully',
+                'data' => $data
+            ], 200);
         } catch (\Exception $e) {
             return response()->json([
-                'status_code' => 500,
-                'success' => false,
-                'message' => 'Failed to update help article. Please try again later.',
-                'error' => $e->getMessage() // Include error message
-            ], 500);
+                'status_code' => 404,
+                'message' => 'Help article not found',
+                'data' => null
+            ], 404);
         }
     }
+    
+
+
     public function destroy($articleId)
     {
         // Ensure the user is authenticated

--- a/routes/api.php
+++ b/routes/api.php
@@ -164,6 +164,7 @@ Route::prefix('v1')->group(function () {
 
     // Help Articles
     Route::post('/help-center/topics', [HelpArticleController::class, 'store']);
+    Route::get('/v1/help-center/topics/{id}', [HelpArticleController::class, 'show']);
     Route::patch('/help-center/topics/{articleId}', [HelpArticleController::class, 'update']);
     Route::delete('/help-center/topics/{articleId}', [HelpArticleController::class, 'destroy']);
     Route::get('/help-center/topics', [HelpArticleController::class, 'getArticles']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -164,7 +164,7 @@ Route::prefix('v1')->group(function () {
 
     // Help Articles
     Route::post('/help-center/topics', [HelpArticleController::class, 'store']);
-    Route::get('/v1/help-center/topics/{id}', [HelpArticleController::class, 'show']);
+    Route::get('/help-center/topics/{articleId}', [HelpArticleController::class, 'show']);
     Route::patch('/help-center/topics/{articleId}', [HelpArticleController::class, 'update']);
     Route::delete('/help-center/topics/{articleId}', [HelpArticleController::class, 'destroy']);
     Route::get('/help-center/topics', [HelpArticleController::class, 'getArticles']);


### PR DESCRIPTION
## Description
An Endpoint for updating an Existing Help Center Topic.

## related link
https://github.com/hngprojects/hng_boilerplate_php_laravel_web/issues/564
https://github.com/hngprojects/hng_boilerplate_nestjs/issues/1045

## Route
`PATCH: /api/v1/help-center/topics/{id}
`
### Response Body
```
{
  "title": "string",
  "content": "string",
  "author": "string"
}
```
![Screenshot (196)](https://github.com/user-attachments/assets/160caaf5-d07d-4f20-8d51-28d8b9141dc3)
