### PR TITLE
[FIX]Retrieving All FAQ Entries 

### DIFF
--- a/app/Http/Controllers/Api/V1/Admin/FaqController.php
+++ b/app/Http/Controllers/Api/V1/Admin/FaqController.php
@@ -26,7 +26,7 @@ class FaqController extends Controller
                 'question' => $validatedData['question'],
                 'answer' => $validatedData['answer'],
                 'category' => $validatedData['category'],
-                // 'role' => Role::USER,
+                'created_by' => auth()->user()->name,
             ]);
 
             return response()->json([
@@ -62,6 +62,7 @@ class FaqController extends Controller
                     'question' => $faq->question,
                     'answer' => $faq->answer,
                     'category' => $faq->category,
+                    'created_by' => $faq->created_by
                 ];
             });
 

--- a/database/migrations/2024_08_08_083933_update_faqs_table.php
+++ b/database/migrations/2024_08_08_083933_update_faqs_table.php
@@ -13,6 +13,7 @@ return new class extends Migration
     {
         Schema::table('faqs', function (Blueprint $table) {
             $table->string('category')->nullable();
+            $table->string('created_by')->nullable();
         });
     }
 

--- a/tests/Feature/FaqControllerTest.php
+++ b/tests/Feature/FaqControllerTest.php
@@ -44,6 +44,7 @@ class FaqControllerTest extends TestCase
                     'category',
                     'created_at',
                     'updated_at',
+                    'created_by'
                 ]
             ]);
 
@@ -58,7 +59,7 @@ class FaqControllerTest extends TestCase
         $payload = [
             'question' => 'Unauthorized question?',
             'answer' => 'This should not be created.',
-            'category' => 'Test'
+            'category' => 'Test',
         ];
 
         $response = $this->withHeaders(['Authorization' => "Bearer $token"])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​
## Description
<!--- Describe your changes in detail -->
​Refactor our current API endpoint for retrieving all FAQ entries.
## Related Issue (Link to Github issue)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
​
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
​
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
​
## Screenshots (if appropriate - Postman, etc):
![faqget](https://github.com/user-attachments/assets/657396ff-9bc2-480b-8839-461151b0aa61)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
