### PR TITLE
Feat/create billing plan

### DIFF
--- a/app/Http/Controllers/BillingPlanController.php
+++ b/app/Http/Controllers/BillingPlanController.php
@@ -42,7 +42,45 @@ class BillingPlanController extends Controller
      */
     public function store(Request $request)
     {
-        //
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'duration' => 'required|string|in:Monthly,Yearly',
+            'price' => 'required|numeric|min:0',
+            'description' => 'required|string',
+        ]);
+
+        try {
+            $billingPlan = SubscriptionPlan::where('name', '=', $validated['name'])->first();
+
+            if($billingPlan){
+                return response()->json([
+                    "status" => "error",
+                    "status_code" => 403,
+                    "message" => "Billing plan alreay exists!",
+                    "data" => []
+                ], 403);
+            }
+
+            $billingPlan = SubscriptionPlan::create($validated);
+
+            return response()->json([
+                "status" => "success",
+                "status_code" => 201,
+                "message" => "Billing plan successfully created!",
+                "data" => [
+                    ...$billingPlan->toArray()
+                ]
+            ], 201);
+
+        } catch (\Throwable $th) {
+            print_r($th);
+                return response()->json([
+                    "status" => "error",
+                    "status_code" => 500,
+                    "message" => "Internal Server Error!",
+                    "data" => []
+                ], 500);
+        }
     }
 
     /**

--- a/app/Http/Controllers/BillingPlanController.php
+++ b/app/Http/Controllers/BillingPlanController.php
@@ -56,7 +56,7 @@ class BillingPlanController extends Controller
                 return response()->json([
                     "status" => "error",
                     "status_code" => 403,
-                    "message" => "Billing plan alreay exists!",
+                    "message" => "Billing plan already exists!",
                     "data" => []
                 ], 403);
             }

--- a/app/Http/Controllers/BillingPlanController.php
+++ b/app/Http/Controllers/BillingPlanController.php
@@ -44,8 +44,9 @@ class BillingPlanController extends Controller
     {
         $validated = $request->validate([
             'name' => 'required|string|max:255',
-            'duration' => 'required|string|in:Monthly,Yearly',
-            'price' => 'required|numeric|min:0',
+            'frequency' => 'required|string|in:Monthly,Yearly',
+            'is_active' => 'boolean',
+            'amount' => 'required|numeric|min:0',
             'description' => 'required|string',
         ]);
 
@@ -61,7 +62,12 @@ class BillingPlanController extends Controller
                 ], 403);
             }
 
-            $billingPlan = SubscriptionPlan::create($validated);
+            $billingPlan = new SubscriptionPlan;
+            $billingPlan->name = $validated['name'];
+            $billingPlan->duration = $validated['frequency'];
+            $billingPlan->price = $validated['amount'];
+            $billingPlan->description = $validated['description'];
+            $billingPlan->save();
 
             return response()->json([
                 "status" => "success",

--- a/resources/docs/docs.json
+++ b/resources/docs/docs.json
@@ -481,6 +481,57 @@
       }
     },
     "/api/v1/billing-plans": {
+        "post": {
+            "summary": "Create new billing plan",
+            "tags": ["Billing"],
+            "security": [
+                {
+                    "bearerAuth": []
+                }
+            ],
+            "requestBody": {
+                "required": true,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/BillingPlan"
+                        }
+                    }
+                }
+            },
+            "responses": {
+                "201": {
+                    "description": "Billing plan created successfully",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BillingPlanResponse"
+                            }
+                        }
+                    }
+                },
+                "403": {
+                    "description": "Billing plan already exists",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ErrorResponse"
+                            }
+                        }
+                    }
+                },
+                "500": {
+                    "description": "Internal Server Error",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ErrorResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        },
       "get": {
         "summary": "Get billing plans",
         "tags": ["Billing"],
@@ -510,7 +561,59 @@
             "description": "Billing plan details retrieved successfully"
           }
         }
-      }
+      },
+      "put": {
+        "summary": "Update billing plan",
+        "tags": ["Billing"],
+        "security": [
+            {
+                "bearerAuth": []
+            }
+        ],
+        "requestBody": {
+            "required": true,
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "$ref": "#/components/schemas/BillingPlan"
+                    }
+                }
+            }
+        },
+        "responses": {
+            "201": {
+                "description": "Billing plan created successfully",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/BillingPlanResponse"
+                        }
+                    }
+                }
+            },
+            "404": {
+                "description": "Billing plan not found",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "500": {
+                "description": "Internal Server Error",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     },
     "/api/v1/payments/paystack/{organisation_id}/verify/{id}": {
       "get": {
@@ -2425,7 +2528,58 @@
           }
         },
         "required": ["type", "content"]
-      }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+            "status": {
+                "type": "string"
+            },
+            "status_code": {
+                "type": "integer"
+            },
+            "message": {
+                "type": "string"
+            },
+            "data": {
+                "type": "object"
+            }
+        }
+      },
+      "BillingPlan": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "duration": {
+            "type": "string"
+          },
+          "price": {
+            "type": "integer"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "BillingPlanResponse": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                },
+                "status_code": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "data": {
+                    "$ref": "#/components/schemas/BillingPlan"
+                }
+            }
+        }
     },
     "securitySchemes": {
       "bearerAuth": {

--- a/routes/api.php
+++ b/routes/api.php
@@ -113,6 +113,7 @@ Route::prefix('v1')->group(function () {
     Route::delete('/products/{product_id}', [ProductController::class, 'delete']);
 
     Route::get('/billing-plans', [BillingPlanController::class, 'index']);
+    Route::post('/billing-plans', [BillingPlanController::class, 'store']);
     Route::get('/billing-plans/{id}', [BillingPlanController::class, 'getBillingPlan']);
     Route::put('/billing-plans/{id}', [BillingPlanController::class, 'update']);
     Route::get('/payments/paystack/{organisation_id}/verify/{id}', [PaymentController::class, 'handlePaystackCallback']);

--- a/tests/Feature/BillingPlanControllerTest.php
+++ b/tests/Feature/BillingPlanControllerTest.php
@@ -5,10 +5,68 @@ namespace Tests\Feature;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use App\Models\SubscriptionPlan;
+use App\Models\User;
+use Tymon\JWTAuth\Facades\JWTAuth;
 
 class BillingPlanControllerTest extends TestCase
 {
     use RefreshDatabase;
+
+    /** @test */
+    public function it_creates_a_billing_plan_successfully()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+        $saved = SubscriptionPlan::where('name', '=', 'Discounted Plan')->first();
+
+        if($saved) $saved->delete();
+
+        $data = [
+            'name' => 'Discounted Plan',
+            'duration' => 'Yearly',
+            'price' => 20000,
+            'description' => 'A discounted plan description',
+        ];
+
+        $response = $this->postJson("/api/v1/billing-plans", $data);
+
+        // Assert: Check the response status and structure
+        $response->assertStatus(201)
+                 ->assertJsonStructure([
+                     'data' => [
+                         'id',
+                         'name',
+                         'duration',
+                         'price',
+                         'description',
+                         'created_at',
+                         'updated_at',
+                     ],
+                     'message',
+                     'status_code',
+                     'status'
+                 ]);
+
+        $this->assertDatabaseHas('subscription_plans',  [
+            'name' => 'Discounted Plan',
+            'duration' => 'Yearly',
+            'price' => 20000,
+            'description' => 'A discounted plan description',
+        ]);
+
+
+        $res = $this->postJson("/api/v1/billing-plans", $data);
+
+        // Assert: Check the response status and structure
+        $res->assertStatus(403)
+                 ->assertJsonStructure([
+                     'data' => [],
+                     'message',
+                     'status_code',
+                     'status'
+                 ]);
+
+    }
 
     /** @test */
     public function it_updates_a_billing_plan_successfully()

--- a/tests/Feature/BillingPlanControllerTest.php
+++ b/tests/Feature/BillingPlanControllerTest.php
@@ -23,8 +23,9 @@ class BillingPlanControllerTest extends TestCase
 
         $data = [
             'name' => 'Discounted Plan',
-            'duration' => 'Yearly',
-            'price' => 20000,
+            'frequency' => 'Yearly',
+            'amount' => 20000,
+            'is_active' => true,
             'description' => 'A discounted plan description',
         ];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​
## Description
<!--- Describe your changes in detail -->
This PR adds an endpoint for creating a new billing plan.
​
## Related Issue (Link to Github issue)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#633 
​
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The API doesn't have an endpoint to create a new billing plan. This is different from the source of truth(NestJS).

​
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Run the app locally using `php artisan serve`
2. In Postman, send a POST request with the following:
Headers:
```
{
   Authorization: "Bearer {your-token}"
}
```
Request Body:
```
{
    "name": "Discounted Plan",
    "duration": "Yearly",
    "is_active": false,
    "price": 20000,
    "description": "A discounted plan description"
}
```
3. You should get either of these responses:
201 - Created Successfully
```
{
    "status": "success",
    "status_code": 201,
    "message": "Billing plan successfully created!",
    "data": {
        "name": "Discounted Plan",
        "duration": "Yearly",
        "price": 20000,
        "description": "A discounted plan description",
        "id": "9e52a242-b1ef-4395-ba8c-b6360be43c99",
        "updated_at": "2025-02-28T21:17:47.000000Z",
        "created_at": "2025-02-28T21:17:47.000000Z"
    }
}
```
403 - Duplicate Billing Plan
```
{
    "status": "error",
    "status_code": 403,
    "message": "Billing plan already exists!",
    "data": []
}
```

500 - Internal Server Error
```
{
    "status": "error",
    "status_code": 500,
    "message": "Internal Server Error!",
    "data": []
}
```
​
## Screenshots (if appropriate - Postman, etc):
Postman:
![image](https://github.com/user-attachments/assets/1d392af7-8d16-43e6-bd33-c758cb728dce)
Passing Tests:
![image](https://github.com/user-attachments/assets/154d6272-e685-40b7-b992-87ee58e39d18)

​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## What this PR entails?
- [x] Creation of a POST endpoint (`api/v1/billing-plans`)
- [x] Updating the billing plan documentation
- [x] Tests for the create billing plan method 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
