### PR TITLE
Feat: activate squeeze page

### DIFF
--- a/app/Http/Controllers/Api/V1/SqueezePageCoontroller.php
+++ b/app/Http/Controllers/Api/V1/SqueezePageCoontroller.php
@@ -93,29 +93,29 @@ class SqueezePageCoontroller extends Controller
 
     public function search(Request $request)
     {
-            $request->validate([
-                'q' => 'required|string|max:255',
-            ]);
+        $request->validate([
+            'q' => 'required|string|max:255',
+        ]);
 
-            $query = SqueezePage::query();
+        $query = SqueezePage::query();
 
-            if ($searchTerm = $request->input('q')) {
-                $query->where(function ($q) use ($searchTerm) {
-                    $q->where('headline', 'LIKE', "%{$searchTerm}%")
-                        ->orWhere('sub_headline', 'LIKE', "%{$searchTerm}%")
-                        ->orWhere('content', 'LIKE', "%{$searchTerm}%")
-                        ->orWhere('title', 'LIKE', "%{$searchTerm}%")
-                        ->orWhere('slug', 'LIKE', "%{$searchTerm}%");
-                });
-            }
+        if ($searchTerm = $request->input('q')) {
+            $query->where(function ($q) use ($searchTerm) {
+                $q->where('headline', 'LIKE', "%{$searchTerm}%")
+                    ->orWhere('sub_headline', 'LIKE', "%{$searchTerm}%")
+                    ->orWhere('content', 'LIKE', "%{$searchTerm}%")
+                    ->orWhere('title', 'LIKE', "%{$searchTerm}%")
+                    ->orWhere('slug', 'LIKE', "%{$searchTerm}%");
+            });
+        }
 
-            $results = $query->get();
+        $results = $query->get();
 
-            return response()->json([
-                'status' => Response::HTTP_OK,
-                'message' => 'Search result retrieved',
-                'data' => $results,
-            ]);
+        return response()->json([
+            'status' => Response::HTTP_OK,
+            'message' => 'Search result retrieved',
+            'data' => $results,
+        ]);
     }
 
     public function filter(FilterSqueezeRequest $request)
@@ -140,5 +140,28 @@ class SqueezePageCoontroller extends Controller
             'message' => 'Filtered results',
             'data' => $results,
         ]);
+    }
+
+    public function activateSqueezePage($id)
+    {
+        try {
+            $squeezePage = SqueezePage::findOrFail($id);
+
+            // Toggle the activate boolean field
+            $squeezePage->activate = !$squeezePage->activate;
+            $squeezePage->save();
+
+            return response()->json([
+                'status' => 'success',
+                'message' => $squeezePage->activate ? 'Squeeze page activated' : 'Squeeze page deactivated',
+                'data' => $squeezePage,
+            ], 200);
+        } catch (\Exception $e) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Failed to toggle activation status',
+                'error' => $e->getMessage()
+            ], 500);
+        }
     }
 }

--- a/app/Http/Controllers/SqueezePageUserController.php
+++ b/app/Http/Controllers/SqueezePageUserController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\SqueezePage;
 use Illuminate\Http\Request;
 use App\Models\SqueezePageUser;
 
@@ -48,11 +49,11 @@ class SqueezePageUserController extends Controller
         $limit = $request->input('limit', 10);
 
         $offset = ($page - 1) * $limit;
-     
+
         $squeezePageUsers = SqueezePageUser::select('firstname', 'lastname', 'email', 'title', 'created_at')
-                ->offset($offset)
-                ->limit($limit)
-                ->get();
+            ->offset($offset)
+            ->limit($limit)
+            ->get();
 
         $totalItems = SqueezePageUser::count();
         $totalPages = ceil($totalItems / $limit);
@@ -61,9 +62,9 @@ class SqueezePageUserController extends Controller
             'message' => 'User details retrieved successfully.',
             'data' => $squeezePageUsers,
             'pagination' => [
-                    'totalItems' => $totalItems,
-                    'totalPages' => $totalPages,
-                    'currentPage' => $page,
+                'totalItems' => $totalItems,
+                'totalPages' => $totalPages,
+                'currentPage' => $page,
             ],
             'status_code' => 200,
         ], 200);

--- a/routes/api.php
+++ b/routes/api.php
@@ -294,6 +294,9 @@ Route::prefix('v1')->group(function () {
         Route::post('/faqs', [FaqController::class, 'store']);
         Route::put('/faqs/{id}', [FaqController::class, 'update']);
         Route::delete('/faqs/{id}', [FaqController::class, 'destroy']);
+
+        // end point to activate a squeeze page
+        Route::patch('/squeeze-pages/{id}/activate', [SqueezePageCoontroller::class, 'activateSqueezePage']);
     });
 
     Route::post('/waitlists', [WaitListController::class, 'store']);
@@ -349,7 +352,6 @@ Route::prefix('v1')->group(function () {
     // Route::get('/quests/{id}/messages', [QuestController::class, 'getQuestMessages']);
 
     Route::post('/squeeze-user', [SqueezePageUserController::class, 'store']);
-
 
     //Newsletter Subscription
     Route::post('newsletter-subscription', [NewsletterSubscriptionController::class, 'store']);

--- a/tests/Feature/SqueezePageActivationTest.php
+++ b/tests/Feature/SqueezePageActivationTest.php
@@ -1,0 +1,127 @@
+<?php
+
+
+
+namespace Tests\Feature;
+
+use App\Models\SqueezePage;
+use App\Models\User;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+
+class SqueezePageActivationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $adminUser;
+    protected $adminToken;
+    // protected $squeezePage;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Create admin user and generate token
+        $this->adminUser = User::factory()->create(['role' => 'admin']);
+        $this->adminToken = JWTAuth::fromUser($this->adminUser);
+    }
+
+    public function test_admin_can_activate_squeeze_page()
+    {
+        // Create a squeeze page with all required fields
+        $squeezePage = SqueezePage::create([
+            'headline' => 'Increase Your Conversions',
+            'sub_headline' => 'Discover Proven Techniques',
+            'hero_image' => 'conversion_secrets.jpg',
+            'content' => 'Find out how to turn visitors into customers...',
+            'title' => 'Conversion Secrets',
+            'slug' => 'conversion-secrets-1',
+            'status' => 'online',
+            'activate' => false,
+        ]);
+
+        $response = $this->withHeaders(['Authorization' => "Bearer {$this->adminToken}"])
+            ->patchJson("/api/v1/squeeze-pages/{$squeezePage->id}/activate");
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'status' => 'success',
+                'message' => 'Squeeze page activated',
+                'data' => [
+                    'id' =>   $squeezePage->id,
+                    'activate' => true
+                ]
+            ]);
+
+        $this->assertTrue($squeezePage->fresh()->activate);
+    }
+
+    public function test_admin_can_deactivate_squeeze_page()
+    {
+        // Create a squeeze page with all required fields
+
+        // Create a test squeeze page
+        $squeezePage = SqueezePage::create([
+            'headline' => 'Increase Your Conversions',
+            'sub_headline' => 'Discover Proven Techniques',
+            'hero_image' => 'conversion_secrets.jpg',
+            'content' => 'Find out how to turn visitors into customers...',
+            'title' => 'Conversion Secrets',
+            'slug' => 'conversion-secrets-2',
+            'status' => 'online',
+            'activate' => true,
+        ]);
+        $response = $this->withHeaders(['Authorization' => "Bearer {$this->adminToken}"])
+            ->patchJson("/api/v1/squeeze-pages/{$squeezePage->id}/activate");
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'status' => 'success',
+                'message' => 'Squeeze page deactivated',
+                'data' => [
+                    'id' =>   $squeezePage->id,
+                    'activate' => false
+                ]
+            ]);
+
+        $this->assertFalse($squeezePage->fresh()->activate);
+    }
+
+    public function test_non_admin_cannot_activate_squeeze_page()
+    {
+        // Create a squeeze page with all required fields
+        $squeezePage = SqueezePage::create([
+            'id' => '9e535fc0-b9b7-4da7-8f6c-295b20997461',
+            'headline' => 'Increase Your Conversions',
+            'sub_headline' => 'Discover Proven Techniques',
+            'hero_image' => 'conversion_secrets.jpg',
+            'content' => 'Find out how to turn visitors into customers...',
+            'title' => 'Conversion Secrets',
+            'slug' => 'dev-tonia',
+            'status' => 'online',
+            'activate' => false,
+        ]);
+
+        $regularUser = User::factory()->create(['role' => 'user']);
+        $userToken = JWTAuth::fromUser($regularUser);
+
+        $response = $this->withHeaders(['Authorization' => "Bearer $userToken"])
+            ->patchJson("/api/v1/squeeze-pages/{$squeezePage->id}/activate");
+
+        $response->assertStatus(401);
+    }
+
+    public function test_activation_fails_for_non_existent_squeeze_page()
+    {
+        $response = $this->withHeaders(['Authorization' => "Bearer $this->adminToken"])
+            ->patchJson("/api/v1/squeeze-pages/999999/activate");
+
+        $response->assertStatus(500)
+            ->assertJson([
+                'status' => 'error',
+                'message' => 'Failed to toggle activation status'
+            ]);
+    }
+}

--- a/tests/Feature/SqueezePagesTest.php
+++ b/tests/Feature/SqueezePagesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\SqueezePage;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;

--- a/tests/Feature/WaitListControllerTest.php
+++ b/tests/Feature/WaitListControllerTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Feature;
 
+use App\Mail\WaitlistConfirmation;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 use App\Models\User;
 use App\Models\WaitList;
@@ -23,77 +25,33 @@ class WaitListControllerTest extends TestCase
      *
      * @return void
      */
-    // public function testIndex()
-    // {
+    public function testIndex()
+    {
+        // Create an admin user
+        $admin = User::factory()->create(['role' => 'admin']);
 
-    //     $admin = User::factory()->create(['role' => 'admin']);
+        // Generate a JWT token for the admin user
+        $token = JWTAuth::fromUser($admin);
 
-    //     // Create some waitlist entries
-    //     WaitList::factory()->count(3)->create();
-    //     $response = $this->actingAs($admin)->getJson('/api/v1/waitlists');
-    //     $response->assertStatus(200);
-    //     $response->assertJsonStructure([
-    //         'status',
-    //         'data' => [
-    //             '*' => ['id', 'name', 'email', 'created_at', 'updated_at']
-    //         ]
-    //     ]);
-    // }
+        // Create some waitlist entries
+        WaitList::factory()->count(3)->create();
 
-//     public function testIndex()
-// {
-//     // Create an admin role
-//     $adminRole = \App\Models\Role::create(['name' => 'admin']);
+        // Act as the admin user with the generated token
+        $response = $this->withHeaders(['Authorization' => 'Bearer ' . $token])
+            ->getJson('/api/v1/waitlists');
 
-//     // Create a user and assign the admin role
-//     $admin = \App\Models\User::factory()->create(); // Create user without role
-//     $admin->roles()->attach($adminRole->id); // Attach the admin role to the user
+        // Assert that the response status is 200
 
-//     // Create some waitlist entries
-//     \App\Models\WaitList::factory()->count(3)->create();
+        $response->assertStatus(200);
 
-//     // Act as the admin user and make a GET request to the index endpoint
-//     $response = $this->actingAs($admin)->getJson('/api/v1/waitlists');
-
-//     // Assert that the response status is 200
-//     $response->assertStatus(200);
-
-//     // Assert that the response contains the correct data structure
-//     $response->assertJsonStructure([
-//         'status',
-//         'data' => [
-//             '*' => ['id', 'name', 'email', 'created_at', 'updated_at']
-//         ]
-//     ]);
-// }
-
-
-public function testIndex()
-{
-    // Create an admin user
-    $admin = User::factory()->create(['role' => 'admin']);
-
-    // Generate a JWT token for the admin user
-    $token = JWTAuth::fromUser($admin);
-
-    // Create some waitlist entries
-    WaitList::factory()->count(3)->create();
-
-    // Act as the admin user with the generated token
-    $response = $this->withHeaders(['Authorization' => 'Bearer ' . $token])
-                     ->getJson('/api/v1/waitlists');
-
-    // Assert that the response status is 200
-    $response->assertStatus(200);
-
-    // Assert that the response contains the correct data structure
-    $response->assertJsonStructure([
-        'status',
-        'data' => [
-            '*' => ['id', 'name', 'email', 'created_at', 'updated_at']
-        ]
-    ]);
-}
+        // Assert that the response contains the correct data structure
+        $response->assertJsonStructure([
+            'status',
+            'data' => [
+                '*' => ['id', 'name', 'email', 'created_at', 'updated_at']
+            ]
+        ]);
+    }
 
 
     /**
@@ -103,45 +61,76 @@ public function testIndex()
      */
     public function testStore()
     {
+        // Fake the mail sending
+        Mail::fake();
 
         $payload = [
             'name' => 'John Doe',
             'email' => 'john.doe@example.com'
         ];
 
-        $response = $this->postJson('/api/v1/waitlists', $payload);
-        $response->assertStatus(201);
-        $response->assertJson([
-            'status' => 201,
-            'message' => 'You have been added to the waitlist and an email has been sent.',
-            'data' => [
-                'name' => 'John Doe',
-                'email' => 'john.doe@example.com'
-            ]
-        ]);
+        $response = $this->withHeaders([
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json'
+        ])->postJson('/api/v1/waitlists', $payload);
 
+        // Enhanced debugging on failure
+        if ($response->status() !== 201) {
+            dump([
+                'Status Code' => $response->status(),
+                'Response Content' => $response->json(),
+                'Validation Errors' => $response->status() === 422 ? $response->json()['message'] : null
+            ]);
+        }
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'status' => 201,
+                'message' => 'You have been added to the waitlist and an email has been sent.',
+                'data' => [
+                    'name' => 'John Doe',
+                    'email' => 'john.doe@example.com'
+                ]
+            ]);
+
+        // Database assertions
         $this->assertDatabaseHas('wait_lists', [
             'name' => 'John Doe',
             'email' => 'john.doe@example.com'
         ]);
+
+        // Mail assertions
+        Mail::assertSent(WaitlistConfirmation::class, function ($mail) {
+            return $mail->hasTo('john.doe@example.com');
+        });
     }
 
-    /**
-     * Test validation failure when storing a new waitlist entry.
-     *
-     * @return void
-     */
     public function testStoreValidationFailure()
     {
+        Mail::fake();
+
         $payload = [
-            'email' => 'invalid-email'
+            'name' => '',  // Invalid: empty name
+            'email' => 'invalid-email'  // Invalid: incorrect email format
         ];
 
-        $response = $this->postJson('/api/v1/waitlists', $payload);
-        $response->assertStatus(422);
-        $response->assertJson([
-            'status' => 422,
-            'message' => 'The name field is required. The email field must be a valid email address.'
+        $response = $this->withHeaders([
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json'
+        ])->postJson('/api/v1/waitlists', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonStructure([
+                'status',
+                'message'
+            ]);
+
+        // Assert no mail was sent
+        Mail::assertNothingSent();
+
+        // Assert nothing was saved to database
+        $this->assertDatabaseMissing('wait_lists', [
+            'email' => 'invalid-email'
         ]);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​
## Description
<!--- Describe your changes in detail -->
​Implement a feature to toggle the status of a "squeeze" . The system should allow users to toggle the status between True (active) and False (inactive). The feature should handle toggling logic and return the updated status in the response.
## Related Issue (Link to Github issue)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[​Issue 639](https://github.com/hngprojects/hng_boilerplate_php_laravel_web/issues/639)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
​
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
​Tested using postman and feature testing 
## Screenshots (if appropriate - Postman, etc):
[Postman](​https://hng12.slack.com/files/U08BBLGQJGY/F08GC28FRUY/image.png)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
