### PR TITLE
JSON Field Assertions in Laravel Tests

### DIFF
--- a/app/Models/EmailRequest.php
+++ b/app/Models/EmailRequest.php
@@ -13,6 +13,9 @@ class EmailRequest extends Model
     protected $table = 'email_requests';
     protected $keyType = 'uuid';
     public $incrementing = false;
+    protected $casts = [
+        'variables' => 'array',
+    ];
     protected $fillable = [
         "template_id",
         "subject",


### PR DESCRIPTION
The 'variables' attribute is now explicitly cast to an array to prevent assertion errors in the EmailRequest test.

Fixes #649