### PR TITLE
feat: Disable Foreign before running seeders

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,6 +20,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
+        // Disable foreign key checks
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
         //create an admin user
         $this->call([
             AdminSeeder::class


### PR DESCRIPTION
Modified DatabaseSeeder.php to temporarily disable foreign key checksbefore truncating tables, ensuring smooth database seeding without constraint violations.

Fixes #626