### PR TITLE
Fix: Create or update notification settings to avoid error when settings doesn’t exist

### DIFF
--- a/app/Http/Controllers/NotificationSettingController.php
+++ b/app/Http/Controllers/NotificationSettingController.php
@@ -72,8 +72,11 @@ class NotificationSettingController extends Controller
             'slack_notifications_announcement_and_update_emails' => 'required|boolean',
         ]);
         $user = Auth::user();
-        $settings = $user->notificationSetting;
-        $settings->update($request->all());
+        $settings = $user->notificationSetting();
+        $settings->updateOrCreate(
+            ['user_id' => $user->id],  // Find existing settings by user_id
+            $request->all()             // Update with new data or create if not found
+        );
         return response()->json([
             'status' => 'success',
             'message' => 'Notification preferences updated successfully',

--- a/tests/Unit/UpdateNotificationPreferenceTest.php
+++ b/tests/Unit/UpdateNotificationPreferenceTest.php
@@ -69,4 +69,33 @@ class UpdateNotificationPreferenceTest extends TestCase
 
         $response->assertStatus(400);
     }
+
+    /** @test */
+    public function it_creates_settings_if_none_exist()
+    {
+        $user = User::factory()->create();
+
+        $data = [
+            'mobile_push_notifications' => true,
+            'email_notification_activity_in_workspace' => true,
+            'email_notification_always_send_email_notifications' => true,
+            'email_notification_email_digest' => true,
+            'email_notification_announcement_and_update_emails' => true,
+            'slack_notifications_activity_on_your_workspace' => true,
+            'slack_notifications_always_send_email_notifications' => true,
+            'slack_notifications_announcement_and_update_emails' => true,
+        ];
+
+        $response = $this->actingAs($user, 'api')
+            ->patchJson('/api/v1/settings/notification-settings', $data);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'status' => 'success',
+                'message' => 'Notification preferences updated successfully',
+                'status_code' => 200,
+            ]);
+
+        $this->assertDatabaseHas('notification_settings', $data + ['user_id' => $user->id]);
+    }
 }


### PR DESCRIPTION
## Description
​This PR ensures that notification settings are created automatically if they don’t already exist when a user attempts to update them. Previously, users without existing notification preferences faced issues updating settings.  

Now, when a `PATCH` request is sent to `/api/v1/settings/notification-settings`, the system checks if a notification preference exists for the user. If none exists, a new record is created before applying the update.

## Related Issue (Link to Github issue)
Closes #657

### Steps to Reproduce:
<img width="1280" alt="Screenshot 2025-03-02 at 19 14 13" src="https://github.com/user-attachments/assets/303cd866-9172-4b4f-8968-d765902ee55f" />

1. Send a `PATCH` request to `/api/v1/settings/notification-settings` with a valid JSON body as shown below, for a user who has no existing notification settings:
   ```json
   {
     "mobile_push_notifications": true,
     "email_notification_activity_in_workspace": true,
     "email_notification_always_send_email_notifications": true,
     "email_notification_email_digest": true,
     "email_notification_announcement_and_update_emails": true,
     "slack_notifications_activity_on_your_workspace": true,
     "slack_notifications_always_send_email_notifications": true,
     "slack_notifications_announcement_and_update_emails": true
   }

2. Observe that the request fails because the application does not create notification settings for users who do not already have them.

3. As a result, users without existing notification settings receive an error instead of having default settings created automatically.
4. This bug prevents users from updating their notification preferences unless their settings already exist in the database.
#657 
​
## Motivation and Context  
This change is required to ensure that users who have not previously set their notification preferences can still update them without encountering errors. Previously, the system expected existing settings, preventing new users from modifying their preferences. This fix allows the system to create default settings if none exist, ensuring a seamless user experience.

​
## How Has This Been Tested?  
- **Unit Test:** Added a new test case `it_creates_settings_if_none_exist` in `UpdateNotificationPreferenceTest.php` to verify that notification settings are created when a user attempts to update settings for the first time.  
- **Manual Testing:**  
  1. Sent a `PATCH` request to `/api/v1/settings/notification-settings` with valid notification settings for a user without existing preferences.  
  2. Verified that the settings were successfully created in the database.  
  3. Confirmed that subsequent updates modify the existing settings instead of creating new ones.  
  4. User's email must be verified before this can work.
- **Thunder Testing:** Used Thunder client to simulate different scenarios, including valid updates, unauthorized access, and invalid data submissions.

<img width="1280" alt="Screenshot 2025-03-02 at 19 12 55" src="https://github.com/user-attachments/assets/ed576ff5-41b8-47be-9292-238e173f171a" />
<img width="1280" alt="Screenshot 2025-03-02 at 19 13 13" src="https://github.com/user-attachments/assets/5a80406d-5381-4e11-8be8-ec488e32b109" />

​
​
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
